### PR TITLE
fix: Move cookies initialization to prevent client creation errors 

### DIFF
--- a/label_studio_sdk/client.py
+++ b/label_studio_sdk/client.py
@@ -74,6 +74,9 @@ class Client(object):
         self.make_request_raise = make_request_raise
         self.session = session or self.get_session()
 
+        # set cookies
+        self.cookies = cookies
+
         # set api key or get it using credentials (username and password)
         if api_key is not None:
             credentials = ClientCredentials(api_key=api_key)
@@ -89,9 +92,6 @@ class Client(object):
             self.headers.update({'Proxy-Authorization': f'Bearer {oidc_token}'})
         if extra_headers:
             self.headers.update(extra_headers)
-
-        # set cookies
-        self.cookies = cookies
 
         # set versions from /version endpoint
         self.versions = versions if versions else self.get_versions()


### PR DESCRIPTION
Corrects #134  

Moving the `cookies` initialization before the `get_api_keys` call to prevent an `AttributeError`.