### PR TITLE
Support null google_application_credentials

### DIFF
--- a/label_studio_sdk/project.py
+++ b/label_studio_sdk/project.py
@@ -1273,7 +1273,7 @@ class Project(Client):
             Number of tasks synced in the last sync
 
         """
-        if os.path.isfile(google_application_credentials):
+        if google_application_credentials and os.path.isfile(google_application_credentials):
             with open(google_application_credentials) as f:
                 google_application_credentials = f.read()
 


### PR DESCRIPTION
Without this check, using the default (None) would result in TypeError: stat: path should be string, bytes, os.PathLike or integer, not NoneType