### PR TITLE
[fix] bump pydantic version and fix unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+__pycache__/

--- a/label_studio_sdk/client.py
+++ b/label_studio_sdk/client.py
@@ -19,8 +19,8 @@ LABEL_STUDIO_DEFAULT_URL = 'http://localhost:8080'
 
 
 class ClientCredentials(BaseModel):
-    email: Optional[str]
-    password: Optional[str]
+    email: Optional[str] = None
+    password: Optional[str] = None
     api_key: Optional[constr()] = None
 
     @root_validator(pre=True, allow_reuse=True)

--- a/label_studio_sdk/client.py
+++ b/label_studio_sdk/client.py
@@ -187,9 +187,7 @@ class Client(object):
 
         params = {'page_size': 10000000}
         params.update(query_params)
-        response = self.make_request(
-            'GET', '/api/projects', params=params
-        )
+        response = self.make_request('GET', '/api/projects', params=params)
         if response.status_code == 200:
             projects = []
             for data in response.json()['results']:
@@ -297,7 +295,9 @@ class Client(object):
             else user
         )
 
-        response = self.make_request('POST', '/api/users', json=payload, raise_exceptions=False)
+        response = self.make_request(
+            'POST', '/api/users', json=payload, raise_exceptions=False
+        )
         user_data = response.json()
         user_data['client'] = self
 
@@ -406,7 +406,8 @@ class Client(object):
                     f'Request URL: {response.url}\n'
                     f'Response status code: {response.status_code}\n'
                     f'Response content:\n{content}\n\n'
-                    f'SDK error traceback:')
+                    f'SDK error traceback:'
+                )
                 response.raise_for_status()
 
         return response

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 lxml>=4.2.5
 requests>=2.22.0,<3
-pydantic<=1.11,>1.7
+pydantic<3,>1.7
 label-studio-tools>=0.0.1

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,22 +1,26 @@
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
 from label_studio_sdk.client import Client
 
 
 def test_client_headers():
+    mock_session = Mock(spec=['request'])
+    mock_session.request.return_value = Mock(status_code=200)
     client = Client(url='http://fake.url', api_key='fake_key',
+                    session=mock_session, versions={'label-studio': '1.0.0'},
                     extra_headers={'Proxy-Authorization': 'Bearer fake_bearer'})
-    with patch('requests.Session.request') as mocked_get:
-        mocked_get.return_value.status_code = 200
-        client.check_connection()
-        args, kwargs = mocked_get.call_args
-        assert kwargs['headers'] == {'Authorization': f'Token fake_key', 'Proxy-Authorization': 'Bearer fake_bearer'}
+
+    client.check_connection()
+    args, kwargs = mock_session.request.call_args
+    assert kwargs['headers'] == {'Authorization': f'Token fake_key', 'Proxy-Authorization': 'Bearer fake_bearer'}
 
 
 def test_client_no_extra_headers():
-    client = Client(url='http://fake.url', api_key='fake_key')
-    with patch('requests.Session.request') as mocked_get:
-        mocked_get.return_value.status_code = 200
-        client.check_connection()
-        args, kwargs = mocked_get.call_args
-        assert kwargs['headers'] == {'Authorization': f'Token fake_key'}
+    mock_session = Mock(spec=['request'])
+    mock_session.request.return_value = Mock(status_code=200)
+    client = Client(url='http://fake.url', api_key='fake_key',
+                    session=mock_session, versions={'label-studio': '1.0.0'})
+
+    client.check_connection()
+    args, kwargs = mock_session.request.call_args
+    assert kwargs['headers'] == {'Authorization': f'Token fake_key'}


### PR DESCRIPTION
- This PR fixes #139 by addressing issues related to the latest Pydantic 2.0 release (default values for the ClientCredentials model)
- Loosen restrictions on Pydantic version to allow V2
- Fixes client unit tests that were failing on main before