### PR TITLE
fix: Adding check for invalid Client instantiation

### DIFF
--- a/label_studio_sdk/client.py
+++ b/label_studio_sdk/client.py
@@ -85,6 +85,13 @@ class Client(object):
 
         if api_key is not None:
             credentials = ClientCredentials(api_key=api_key)
+
+        if api_key is None and credentials is None:
+            raise RuntimeError(
+                "If neither 'api_key' nor 'credentials' are provided, 'LABEL_STUDIO_API_KEY' environment variable must "
+                "be set"
+            )
+
         self.api_key = (
             credentials.api_key
             if credentials.api_key


### PR DESCRIPTION
This solves #145 
I just added a check and error message in case the user attempts to instantiate the Client improperly.

Now this is what happens if you instantiate a Client with no arguments and no env var set:
```python
>>> import label_studio_sdk
>>> label_studio_sdk.Client()
```
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/path/to/label_studio_sdk/client.py", line 90, in __init__
    raise RuntimeError(
RuntimeError: If neither 'api_key' nor 'credentials' are provided, 'LABEL_STUDIO_API_KEY' environment variable must be set
```