### PR TITLE
fix: LSDV-5564: Suppress error message on normal end of pagination

### DIFF
--- a/label_studio_sdk/__init__.py
+++ b/label_studio_sdk/__init__.py
@@ -5,4 +5,4 @@ from .project import Project
 from .utils import parse_config
 
 
-__version__ = '0.0.32.dev'
+__version__ = '0.0.31'

--- a/label_studio_sdk/client.py
+++ b/label_studio_sdk/client.py
@@ -403,21 +403,24 @@ class Client(object):
 
         if raise_exceptions:
             if response.status_code >= 400:
-                try:
-                    content = json.dumps(json.loads(response.content), indent=2)
-                except:
-                    content = response.text
-
-                logger.error(
-                    f'\n--------------------------------------------\n'
-                    f'Request URL: {response.url}\n'
-                    f'Response status code: {response.status_code}\n'
-                    f'Response content:\n{content}\n\n'
-                    f'SDK error traceback:'
-                )
+                self.log_response_error(response)
                 response.raise_for_status()
 
         return response
+
+    def log_response_error(self, response):
+        try:
+            content = json.dumps(json.loads(response.content), indent=2)
+        except:
+            content = response.text
+
+        logger.error(
+            f'\n--------------------------------------------\n'
+            f'Request URL: {response.url}\n'
+            f'Response status code: {response.status_code}\n'
+            f'Response content:\n{content}\n\n'
+            f'SDK error traceback:'
+        )
 
     def sync_storage(self, storage_type, storage_id):
         """Synchronize Cloud Storage.

--- a/label_studio_sdk/project.py
+++ b/label_studio_sdk/project.py
@@ -503,7 +503,7 @@ class Project(Client):
                 url=f'/api/projects/{self.id}/import',
                 json=tasks,
                 params=params,
-                timeout=(10, 600)
+                timeout=(10, 600),
             )
         elif isinstance(tasks, (str, Path)):
             # try import from file
@@ -515,7 +515,7 @@ class Project(Client):
                     url=f'/api/projects/{self.id}/import',
                     files={'file': f},
                     params=params,
-                    timeout=(10, 600)
+                    timeout=(10, 600),
                 )
         else:
             raise TypeError(
@@ -816,7 +816,9 @@ class Project(Client):
         if only_ids:
             params['include'] = 'id'
 
-        response = self.make_request('GET', '/api/tasks', params, raise_exceptions=False)
+        response = self.make_request(
+            'GET', '/api/tasks', params, raise_exceptions=False
+        )
         # we'll get 404 from API on empty page
         if response.status_code == 404:
             return {'tasks': [], 'end_pagination': True}


### PR DESCRIPTION
Before

```
jo@xxc:~/Repos/label-studio-sdk$ PYTHONPATH=. python tests/test_driver.py 

--------------------------------------------
Request URL: https://app.heartex.com/api/tasks?project=34506&page=2&page_size=100&query=%7B%22filters%22%3A+null%2C+%22ordering%22%3A+%5B%5D%2C+%22selectedItems%22%3A+%7B%22all%22%3A+true%2C+%22excluded%22%3A+%5B%5D%7D%7D&fields=all&resolve_uri=True
Response status code: 404
Response content:
{
  "id": "...",
  "status_code": 404,
  "version": "1.8.3dev",
  "detail": "Invalid page.",
  "exc_info": null
}

SDK error traceback:
proj=34506 got tasks: tasks=[]

```

After

```
jo@xxc:~/Repos/label-studio-sdk$ PYTHONPATH=. python tests/test_driver.py 
proj=39570 got tasks: tasks=[{'id': 65823440, ...}, {'id': 67404521, ...}, {'id': 67404522, ...}]
jo@xxc:~/Repos/label-studio-sdk$ PYTHONPATH=. python tests/test_driver.py 
proj=34506 got tasks: tasks=[]
```
