### PR TITLE
docs: link fix and PR naming section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,18 @@ Follow these code formatting guidelines:
 - Include unit tests when you contribute bug fixes and new features. Unit tests help prove that your code works correctly and protects against future breaking changes.
 - Make sure that the code coverage checks and automatic tests for pull requests pass. 
 
+### Pull Request naming
+Use one of the following prefixes for the title of your PR:
+- `fix: `
+- `feat: `
+- `docs: `
+- `chore: `
+- `ci: `
+- `perf: `
+- `refactor: `
+- `style: `
+- `test: `
+
 ### Additional questions
 
 If you have any questions that aren't answered in these guidelines, please find us in the #contributor channel of the [Label Studio Slack Community](https://slack.labelstud.io/?source=github-sdk-contrib).

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This is the first release of the Label Studio SDK. It supports Label Studio Ente
 
 - **Find a bug?** [Create a GitHub issue](https://github.com/heartexlabs/label-studio-sdk/issues)!
 - **Have a question?** [Join the Slack Community](https://slack.labelstud.io/?source=github-sdk)!
-- **Want to contribute?** [See the contributing guide](https://github.com/heartexlabs/label-studio-sdk/CONTRIBUTING.md)
+- **Want to contribute?** [See the contributing guide](CONTRIBUTING.md)
 
 ## Quickstart
 To start using the SDK in your machine learning and data science projects and pipelines, do the following:


### PR DESCRIPTION
Small update fixing the link in README.md and adding a section about PR naming into CONTRIBUTING.md because for now it's not displayed anywhere except the configuration of GH actions. 