### PR TITLE
docs: Remove broken image link

### DIFF
--- a/docs/project.md
+++ b/docs/project.md
@@ -2,4 +2,3 @@
 
 This section contains project operations that you can perform with the SDK. See the [client](client.html), [data manager](data_manager.html) or [utils](utils.html) modules for other operations you might want to perform. 
 
-<img src="https://assets.website-files.com/612013f17754cb859455543d/612767b9650003e2b806994b_opossum.svg">


### PR DESCRIPTION
SDK project page had a broken image link to a Heidi SVG. There isn't a good substitute for this image, and it isn't necessary for the content, so removing it. 