### PR TITLE
fixes for pydantic v2

### DIFF
--- a/label_studio_sdk/users.py
+++ b/label_studio_sdk/users.py
@@ -1,7 +1,9 @@
 from datetime import datetime
-from pydantic import BaseModel
 from enum import Enum
 from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
 from .client import Client
 
 
@@ -30,8 +32,8 @@ class User(BaseModel):
     last_activity: datetime
     initials: str
     phone: str
-    active_organization: Optional[int]
-    org_membership: Optional[List[OrgMembership]]
+    active_organization: Optional[int] = None
+    org_membership: Optional[List[OrgMembership]] = Field(default_factory=list)
     client: Client
 
     class Config:

--- a/label_studio_sdk/workspaces.py
+++ b/label_studio_sdk/workspaces.py
@@ -1,13 +1,15 @@
+from typing import Optional
+
 from pydantic import BaseModel
-from typing import List, Optional
-from .users import User
+
 from .client import Client
+from .users import User
 
 
 class Workspace(BaseModel):
     id: int
     title: str
-    description: Optional[str]
+    description: Optional[str] = ''
     color: str
     is_personal: bool
     created_by: int


### PR DESCRIPTION
# Overview
`pydantic<3,>1.7` from the `requirements.txt` resolves to v.6.1, which has some backwards incompatibility with v1

## Reproducing
Code snippet to reproduce:
```python
from label_studio_sdk import Client

API_KEY = os.environ["LABEL_STUDIO_API_KEY"]
ls = Client(url=LABEL_STUDIO_URL, api_key=API_KEY)
assert ls.check_connection()["status"] == "UP", 'Connection status is not UP'
user_table = ls.get_users()
```

Error:
```shell
pydantic_core._pydantic_core.ValidationError: 1 validation error for User
org_membership
  Field required [type=missing, input_value={'id': 1, 'first_name': '...ject at 0x7f9712a4ff50>}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.6/v/missing
```

# Details

`Client.get_users` [makes an API call](https://github.com/HumanSignal/label-studio-sdk/blob/7ec493e6e9ff128e089553c25f866f80dab26023/label_studio_sdk/client.py#L268) to `/api/users` which never returns an `org_membership` field, according to the [API reference](https://labelstud.io/api#tag/Users/operation/api_users_list)

The `Optional` field [works differently](https://docs.pydantic.dev/latest/migration/#required-optional-and-nullable-fields) in Pydantic v2, and is actually required.

# Fix

- Added defaults for some `Optional` fields
- Sorted some imports with `isort`