### PR TITLE
fix: Excluding docs from setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
     long_description="Label Studio Python SDK",
     long_description_content_type="text/markdown",
     url="https://github.com/heartexlabs/label-studio-sdk",
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=["docs"]),
     include_package_data=True,
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
This MR attempts to exclude the `docs` directory from `setuptools` based on a requested change in the following PR:

https://github.com/conda-forge/staged-recipes/pull/25567