### PR TITLE
fix: setup.py regex doesn't match version in init file

### DIFF
--- a/label_studio_sdk/__init__.py
+++ b/label_studio_sdk/__init__.py
@@ -8,4 +8,4 @@ from .utils import parse_config
 __pdoc__ = {"label_interface": False}
 
 
-__version__ = '0.0.34.dev'
+__version__ = "0.0.34.dev"


### PR DESCRIPTION
Fixes broken setup.py