### PR TITLE
fix: version parsing in setup.py 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open("requirements.txt") as f:
 
 # parse version from label_studio_sdk/__init__.py without importing the package
 with open("label_studio_sdk/__init__.py") as f:
-    version = re.search(r'__version__ = "(.*?)"', f.read()).group(1)
+    version = re.search(r'__version__ = \'(.*?)\'', f.read()).group(1)
 
 setuptools.setup(
     name="label-studio-sdk",


### PR DESCRIPTION
Fixed installing of the package. I used `pip install -e .` inside the repo folder to test that it did'nt worked before and now works. 
Tested this in python 3.10. 

Error I got before was:
```
Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/home/my/cool/path/label-studio-sdk/setup.py", line 16, in <module>
          version = re.search(r'__version__ = "(.*?)"', f.read()).group(1)
      AttributeError: 'NoneType' object has no attribute 'group'
```
      