### PR TITLE
fix: DIA-1123: Handle config with invalid Label tag (no value)

### DIFF
--- a/label_studio_sdk/label_interface/interface.py
+++ b/label_studio_sdk/label_interface/interface.py
@@ -429,6 +429,8 @@ class LabelInterface:
 
             elif LabelTag.validate_node(tag):
                 lb = LabelTag.parse_node(tag, controls)
+                # This case is hit when Label tag is missing `value` and `alias`
+                # For now we will skip that Label, but in future might want to raise an error
                 if lb:
                     labels[lb.parent_name][lb.value] = lb
 

--- a/label_studio_sdk/label_interface/interface.py
+++ b/label_studio_sdk/label_interface/interface.py
@@ -429,7 +429,8 @@ class LabelInterface:
 
             elif LabelTag.validate_node(tag):
                 lb = LabelTag.parse_node(tag, controls)
-                labels[lb.parent_name][lb.value] = lb
+                if lb:
+                    labels[lb.parent_name][lb.value] = lb
 
         return controls, objects, labels, xml_tree
 

--- a/tests/test_interface/configs.py
+++ b/tests/test_interface/configs.py
@@ -135,3 +135,13 @@ EMPTY_VALUE_CONF = f"""
   </Labels>
 </View>
 """
+
+NO_VALUE_CONF = f"""
+<View>
+  <Text name="text" value="$text"/>
+  <Labels name="type" toName="text">
+    <Label />
+    <Label value="" />
+  </Labels>
+</View>
+"""

--- a/tests/test_interface/test_main.py
+++ b/tests/test_interface/test_main.py
@@ -194,3 +194,4 @@ def test_load_random_task():
 
 def test_empty_value_config():
     conf = LabelInterface(c.EMPTY_VALUE_CONF)
+    conf = LabelInterface(c.NO_VALUE_CONF)


### PR DESCRIPTION
Builds on a fix made yesterday - https://github.com/HumanSignal/label-studio-sdk/pull/212

That handled the case where a `value` of a `Label` was an empty string. However in prod it seems we have some projects that dont have a `value` at all - which should be invalid and not pass validation - but somehow they exist. 

Now this change will handle configs like this to not break, we will just be skipping this label for now and not raising an error. Might want to in the future.

```
<View>
  <Text name="text" value="$text"/>
  <Labels name="type" toName="text">
    <Label />
    <Label value="" />
  </Labels>
</View>
```