### PR TITLE
docs: Fix import Client command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 > 
 > OR you can change your import statements as follows:
 > ```python
-> from label_studio_sdk._legacy import Client
+> from label_studio_sdk import Client
 > from label_studio_sdk.data_manager import Filters, Column, Operator, Type
 > from label_studio_sdk._legacy import Project
 > ```


### PR DESCRIPTION
README section on using legacy SDK had an error. 

`from label_studio_sdk._legacy import Client`
-->
`from label_studio_sdk import Client`