### PR TITLE
fix: Change YOLO import default image extension choices to .jpg, .jpeg, .png

### DIFF
--- a/src/label_studio_sdk/converter/imports/yolo.py
+++ b/src/label_studio_sdk/converter/imports/yolo.py
@@ -218,7 +218,7 @@ def add_parser(subparsers):
         "--image-ext",
         dest="image_ext",
         help="image extension to search: .jpeg or .jpg, .png",
-        default=".jpg",
+        default=".jpg,jpeg,.png",
     )
     yolo.add_argument(
         "--image-dims",


### PR DESCRIPTION
This simple PR fixes the default image extension choices when using label-studio-converter to import YOLO data. 
- In `yolo.py`, the function definition for `convert_yolo_to_ls` uses `image_ext=".jpg,.jpeg,.png"` as the default image extension options. However, this default choice is overridden by the default `--image-ext` argument, which is just `".jpg"`.
- The PR changes the default choices in the `--image-ext` argument to match the function default, because it seems like that's what was intended by the original authors of the code.
- It changes the default `--image-ext` argument from `".jpg"` to `".jpg,.jpeg.png"`

Ultimately, this change makes it easier for a new user to use `label-studio-converter` without having to know about the `--image-ext` argument, which isn't documented anywhere. The [Tutorial: Importing Local YOLO Pre-Annotated Images to Label Studio](https://labelstud.io/blog/tutorial-importing-local-yolo-pre-annotated-images-to-label-studio/) doesn't discuss the `--image_ext` argument at all, so new users could potentially be tripped up when they try to import images that aren't `.jpg`.