### PR TITLE
fix: LEAP-1379: disable non-functional export types for MIG projects

### DIFF
--- a/src/label_studio_sdk/_extensions/label_studio_tools/core/label_config.py
+++ b/src/label_studio_sdk/_extensions/label_studio_tools/core/label_config.py
@@ -100,7 +100,7 @@ def parse_config(config_string):
             actual_value = tag.attrib.get("alias") or tag.attrib.get("value") or tag.attrib.get("valueList")
             if not actual_value:
                 logger.debug(
-                    'Inspecting tag {tag_name}... found no "value" or "alias" attributes.'.format(
+                    'Inspecting tag {tag_name}... found no "value", "valueList", or "alias" attributes.'.format(
                         tag_name=etree.tostring(tag, encoding="unicode").strip()[:50]
                     )
                 )

--- a/src/label_studio_sdk/_extensions/label_studio_tools/core/label_config.py
+++ b/src/label_studio_sdk/_extensions/label_studio_tools/core/label_config.py
@@ -84,9 +84,9 @@ def parse_config(config_string):
                 "valueType": tag.attrib.get("valueType"),
             }
             if 'value' in tag.attrib:
-                inputs[tag.attrib["name"]]["value"] = tag.attrib["value"]
+                inputs[tag.attrib["name"]]["value"] = tag.attrib["value"].lstrip("$")
             elif 'valueList' in tag.attrib:
-                inputs[tag.attrib["name"]]["valueList"] = tag.attrib["valueList"]
+                inputs[tag.attrib["name"]]["valueList"] = tag.attrib["valueList"].lstrip("$")
             else:
                 raise ValueError(
                     'Inspecting tag {tag_name}... found no "value" or "valueList" attributes.'.format(

--- a/src/label_studio_sdk/_extensions/label_studio_tools/core/label_config.py
+++ b/src/label_studio_sdk/_extensions/label_studio_tools/core/label_config.py
@@ -38,6 +38,7 @@ def parse_config(config_string):
     """
     if not config_string:
         return {}
+
     try:
         xml_tree = etree.fromstring(config_string)
     except etree.XMLSyntaxError as e:

--- a/src/label_studio_sdk/_extensions/label_studio_tools/core/label_config.py
+++ b/src/label_studio_sdk/_extensions/label_studio_tools/core/label_config.py
@@ -38,7 +38,6 @@ def parse_config(config_string):
     """
     if not config_string:
         return {}
-
     try:
         xml_tree = etree.fromstring(config_string)
     except etree.XMLSyntaxError as e:
@@ -82,14 +81,23 @@ def parse_config(config_string):
         elif _is_input_tag(tag):
             inputs[tag.attrib["name"]] = {
                 "type": tag.tag,
-                "value": tag.attrib["value"].lstrip("$"),
                 "valueType": tag.attrib.get("valueType"),
             }
+            if 'value' in tag.attrib:
+                inputs[tag.attrib["name"]]["value"] = tag.attrib["value"]
+            elif 'valueList' in tag.attrib:
+                inputs[tag.attrib["name"]]["valueList"] = tag.attrib["valueList"]
+            else:
+                raise ValueError(
+                    'Inspecting tag {tag_name}... found no "value" or "valueList" attributes.'.format(
+                        tag_name=etree.tostring(tag, encoding="unicode").strip()[:50]
+                    )
+                )
         if tag.tag not in _LABEL_TAGS:
             continue
         parent_name = _get_parent_output_tag_name(tag, outputs)
         if parent_name is not None:
-            actual_value = tag.attrib.get("alias") or tag.attrib.get("value")
+            actual_value = tag.attrib.get("alias") or tag.attrib.get("value") or tag.attrib.get("valueList")
             if not actual_value:
                 logger.debug(
                     'Inspecting tag {tag_name}... found no "value" or "alias" attributes.'.format(
@@ -137,7 +145,7 @@ def _is_input_tag(tag):
     """
     Check if tag is input
     """
-    return tag.attrib.get("name") and tag.attrib.get("value")
+    return tag.attrib.get("name") and (tag.attrib.get("value") or tag.attrib.get("valueList"))
 
 
 def _is_output_tag(tag):

--- a/src/label_studio_sdk/converter/converter.py
+++ b/src/label_studio_sdk/converter/converter.py
@@ -10,7 +10,6 @@ from copy import deepcopy
 from datetime import datetime
 from enum import Enum
 from glob import glob
-from operator import itemgetter
 from shutil import copy2
 from typing import Optional
 

--- a/src/label_studio_sdk/converter/converter.py
+++ b/src/label_studio_sdk/converter/converter.py
@@ -291,7 +291,7 @@ class Converter(object):
         return list(data_keys), output_tag_names
 
     def _get_supported_formats(self):
-        is_MIG = False
+        is_mig = False
         if len(self._data_keys) > 1:
             return [
                 Format.JSON.name,
@@ -305,7 +305,7 @@ class Converter(object):
             output_tag_types.add(info["type"])
             for input_tag in info["inputs"]:
                 if input_tag.get("valueList"):
-                    is_MIG = True
+                    is_mig = True
                 if input_tag["type"] == "Text" and input_tag.get("valueType") == "url":
                     logger.error('valueType="url" are not supported for text inputs')
                     continue
@@ -314,7 +314,7 @@ class Converter(object):
         all_formats = [f.name for f in Format]
         if not ("Text" in input_tag_types and "Labels" in output_tag_types):
             all_formats.remove(Format.CONLL2003.name)
-        if is_MIG or not (
+        if is_mig or not (
             "Image" in input_tag_types
             and (
                 "RectangleLabels" in output_tag_types
@@ -323,7 +323,7 @@ class Converter(object):
             )
         ):
             all_formats.remove(Format.VOC.name)
-        if is_MIG or not (
+        if is_mig or not (
             "Image" in input_tag_types
             and (
                 "RectangleLabels" in output_tag_types
@@ -352,7 +352,7 @@ class Converter(object):
             and "TextArea" in output_tag_types
         ):
             all_formats.remove(Format.ASR_MANIFEST.name)
-        if is_MIG or ('Video' in input_tag_types and 'TimelineLabels' in output_tag_types):
+        if is_mig or ('Video' in input_tag_types and 'TimelineLabels' in output_tag_types):
             all_formats.remove(Format.YOLO_OBB.name)
 
         return all_formats

--- a/tests/custom/label_studio_tools/test_core_label_config.py
+++ b/tests/custom/label_studio_tools/test_core_label_config.py
@@ -75,7 +75,7 @@ def test_dynamic_labels_parse_config():
                   <Image name="image" value="$image" zoom="true"/>
                   <PolygonLabels name="label" toName="image"
                                  strokeWidth="3" pointSize="small"
-                                 opacity="0.9" value="$options"    
+                                 opacity="0.9" value="$options"
                   />
                 </View>"""
     )
@@ -93,7 +93,7 @@ def test_no_dynamic_labels_parse_config():
                   <Image name="image" value="$image" zoom="true"/>
                   <PolygonLabels name="label" toName="image"
                                  strokeWidth="3" pointSize="small"
-                                 opacity="0.9"    
+                                 opacity="0.9"
                   />
                 </View>"""
     )
@@ -123,7 +123,7 @@ def test_not_dynamic_labels_parse_config():
                   <Image name="image" value="$image" zoom="true"/>
                   <PolygonLabels name="label" toName="image"
                                  strokeWidth="3" pointSize="small"
-                                 opacity="0.9"    
+                                 opacity="0.9"
                   />
                 </View>"""
     )
@@ -145,3 +145,21 @@ def test_label_config_with_valueType_url():
             </View>"""
     config = parse_config(label_config)
     assert config["text_class"]["inputs"][0]["valueType"] == "url"
+
+
+def test_mig_label_config():
+    """
+    Test MIG config
+    """
+    label_config = """
+    <View>
+      <Image name="image" valueList="$images"/>
+      <RectangleLabels name="labels" toName="image">
+        <Label value="Cat"/>
+        <Label value="Dog"/>
+      </RectangleLabels>
+    </View>
+    """
+
+    config = parse_config(label_config)
+    assert config["labels"]["inputs"][0] == {'type': 'Image', 'valueList': 'images', 'valueType': None}


### PR DESCRIPTION
Parse a labeling config containing an Image tag with `valueList` like so:

```
{'type': 'Image', 'valueList': 'images', 'valueType': None}
```

and in formats calculation, if any input tag has `valueList` in it, set `is_mig` and don't allow COCO, YOLO, YOLO-OBB, or VOC