### PR TITLE
fix: DIA-1518: tasks containing text which starts with a URL fail to load in Prompts

### DIFF
--- a/src/label_studio_sdk/label_interface/object_tags.py
+++ b/src/label_studio_sdk/label_interface/object_tags.py
@@ -153,6 +153,14 @@ class ObjectTag(LabelStudioTag):
             "value": '$' + self.value if self.value is not None else None
         }
 
+    @property
+    def is_url(self) -> bool:
+        """
+        Check if the value is a url that should be dereferenced before using.
+        Can only be true for Text, HyperText, or TimeSeries
+        """
+        return self.attr.get('resolver') or (self.value_type == "url")
+
     # and have generate_example in each
     def generate_example_value(self, mode="upload", secure_mode=False):
         """ """


### PR DESCRIPTION
add check for url function to ObjectTag