### PR TITLE
fix: skip invalid labels in exporting procedure

### DIFF
--- a/src/label_studio_sdk/converter/converter.py
+++ b/src/label_studio_sdk/converter/converter.py
@@ -920,6 +920,8 @@ class Converter(object):
                             annotations.append([category_id, x, y, w, h])
 
                     elif "polygonlabels" in label or "polygon" in label:
+                        if not ('points' in label):
+                            continue
                         points_abs = [(x / 100, y / 100) for x, y in label["points"]]
                         annotations.append(
                             [category_id]


### PR DESCRIPTION
This change fixes Issue #365, where the export process failed due to polygons with zero points. I added a condition to check for empty polygons and skip those annotations using a `continue` statement. This ensures that only valid polygons with points are processed, preventing the error during export.