### PR TITLE
fix: DIA-1581: Enhance prompt not working with number/rating tags

### DIFF
--- a/src/label_studio_sdk/label_interface/control_tags.py
+++ b/src/label_studio_sdk/label_interface/control_tags.py
@@ -475,7 +475,7 @@ class ControlTag(LabelStudioTag):
         for value in values:
             if len(value) == 1 and self._label_attr_name in value:
                 v = value[self._label_attr_name]
-                labels.append(v[0] if len(v) == 1 else v)
+                labels.append(v[0] if type(v) == list else v)
             else:
                 labels.append(value)
         return labels[0] if len(labels) == 1 else labels

--- a/src/label_studio_sdk/label_interface/control_tags.py
+++ b/src/label_studio_sdk/label_interface/control_tags.py
@@ -475,7 +475,7 @@ class ControlTag(LabelStudioTag):
         for value in values:
             if len(value) == 1 and self._label_attr_name in value:
                 v = value[self._label_attr_name]
-                labels.append(v[0] if type(v) == list else v)
+                labels.append(v[0] if type(v) == list and len(v) == 1 else v)
             else:
                 labels.append(value)
         return labels[0] if len(labels) == 1 else labels


### PR DESCRIPTION
When using `get_labels` for a Rating or Number tag, we were hitting a runtime error trying to get `len(v)` since Rating/Number annotations are not stored in a List like Choices, Labels, etc - it is just an `int` 