### PR TITLE
fix: poetry-core 2.0.0 PEP 621 compatibility issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,5 +66,5 @@ plugins = ["pydantic.mypy"]
 
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core<2.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Due to the upgrade of poetry-core to version [2.0.0](https://github.com/python-poetry/poetry-core/releases/tag/2.0.0) with PEP 621 enabled, a project name is now mandatory. After searching, I found that #308 doesn't solve the issue, so I will lock the poetry-core version to be lower than 2.0.0.