### PR TITLE
fix: LEAP-1758: prevent use of poetry-core 2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: "Install poetry"
-        run: pipx install poetry
+        run: pipx install poetry<2.0.0
 
       - name: "Set up Python"
         id: setup_python

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: "Install poetry"
-        run: pipx install poetry<2.0.0
+        run: pipx install "poetry<2.0.0"
 
       - name: "Set up Python"
         id: setup_python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,5 +66,5 @@ plugins = ["pydantic.mypy"]
 
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core<2.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Fixes this error when LS SDK is used as a dependency in other builds

```
The Poetry configuration is invalid:
  - The fields ['name'] are required in package mode.
```