### PR TITLE
Move "version" to [project] as per pyproject.toml spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Explore the Label Studio API documentation [here](https://api.labelstud.io/).
 ```sh
 pip install --upgrade label-studio-sdk
 # or
-poetry add label-studio-sdk
+poetry install
 ```
 
 # Usage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "label-studio-sdk"
+version = "1.0.9"
 
 [tool.poetry]
 name = "label-studio-sdk"
-version = "1.0.9"
 description = ""
 readme = "README.md"
 authors = []
@@ -54,7 +54,7 @@ typing_extensions = ">= 4.0.0"
 ujson = ">=5.8.0"
 xmljson = "0.2.1"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 mypy = "1.0.1"
 pytest = "^7.4.0"
 pytest-asyncio = "^0.23.5"


### PR DESCRIPTION
We tried installing a [label-studio-ml-backend](https://github.com/HumanSignal/label-studio-ml-backend) project that depends on this SDK using the `uv` python environment and package management system.

The installation (with `uv sync`) failed [in the same way as this issue](https://github.com/astral-sh/uv/issues/9910); `uv` has a strict interpretation of the `pyproject.toml` spec and will bail out if the `[project]` table has no version information.
 
* Moves the `version` property from `tools.poetry` into `project`
* Change the `dev-dependencies` table name to `group-dev-dependencies` to avoid a deprecation warning
* Update the README to suggest `poetry install` rather than `poetry add label-studio-sdk` which also throws an error

`uv` is getting more uptake and it's worth ensuring your package is installable with it!

Thanks for your work on the project