### PR TITLE
fix: Project ID in create method

### DIFF
--- a/src/label_studio_sdk/projects/client.py
+++ b/src/label_studio_sdk/projects/client.py
@@ -251,12 +251,22 @@ class ProjectsClient:
         )
         try:
             if 200 <= _response.status_code < 300:
-                return typing.cast(
-                    ProjectsCreateResponse,
-                    parse_obj_as(
-                        type_=ProjectsCreateResponse,  # type: ignore
-                        object_=_response.json(),
-                    ),
+                response_json = _response.json()
+                return ProjectsCreateResponse(
+                    id=response_json.get("id"),
+                    title=response_json.get("title"),
+                    description=response_json.get("description"),
+                    label_config=response_json.get("label_config"),
+                    expert_instruction=response_json.get("expert_instruction"),
+                    show_instruction=response_json.get("show_instruction"),
+                    show_skip_button=response_json.get("show_skip_button"),
+                    enable_empty_annotation=response_json.get("enable_empty_annotation"),
+                    show_annotation_history=response_json.get("show_annotation_history"),
+                    reveal_preannotations_interactively=response_json.get("reveal_preannotations_interactively"),
+                    show_collab_predictions=response_json.get("show_collab_predictions"),
+                    maximum_annotations=response_json.get("maximum_annotations"),
+                    color=response_json.get("color"),
+                    control_weights=response_json.get("control_weights"),
                 )
             _response_json = _response.json()
         except JSONDecodeError:
@@ -935,12 +945,22 @@ class AsyncProjectsClient:
         )
         try:
             if 200 <= _response.status_code < 300:
-                return typing.cast(
-                    ProjectsCreateResponse,
-                    parse_obj_as(
-                        type_=ProjectsCreateResponse,  # type: ignore
-                        object_=_response.json(),
-                    ),
+                response_json = _response.json()
+                return ProjectsCreateResponse(
+                    id=response_json.get("id"),
+                    title=response_json.get("title"),
+                    description=response_json.get("description"),
+                    label_config=response_json.get("label_config"),
+                    expert_instruction=response_json.get("expert_instruction"),
+                    show_instruction=response_json.get("show_instruction"),
+                    show_skip_button=response_json.get("show_skip_button"),
+                    enable_empty_annotation=response_json.get("enable_empty_annotation"),
+                    show_annotation_history=response_json.get("show_annotation_history"),
+                    reveal_preannotations_interactively=response_json.get("reveal_preannotations_interactively"),
+                    show_collab_predictions=response_json.get("show_collab_predictions"),
+                    maximum_annotations=response_json.get("maximum_annotations"),
+                    color=response_json.get("color"),
+                    control_weights=response_json.get("control_weights"),
                 )
             _response_json = _response.json()
         except JSONDecodeError:

--- a/src/label_studio_sdk/projects/types/projects_create_response.py
+++ b/src/label_studio_sdk/projects/types/projects_create_response.py
@@ -11,6 +11,11 @@ class ProjectsCreateResponse(UniversalBaseModel):
     Project
     """
 
+    id: typing.Optional[int] = pydantic.Field(default=None)
+    """
+    Project ID
+    """
+
     title: typing.Optional[str] = pydantic.Field(default=None)
     """
     Project title

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -8,6 +8,7 @@ from .utilities import validate_response
 
 async def test_create(client: LabelStudio, async_client: AsyncLabelStudio) -> None:
     expected_response: typing.Any = {
+        "id": 1,
         "title": "My project",
         "description": "My first project",
         "label_config": "<View>[...]</View>",
@@ -25,6 +26,7 @@ async def test_create(client: LabelStudio, async_client: AsyncLabelStudio) -> No
         },
     }
     expected_types: typing.Any = {
+        "id": "integer",
         "title": None,
         "description": None,
         "label_config": None,


### PR DESCRIPTION
Add project ID to `ProjectsCreateResponse` object in `ProjectsClient` class.

* Add `id` field of type `int` to `ProjectsCreateResponse` class in `src/label_studio_sdk/projects/types/projects_create_response.py`
* Update `create` method in `ProjectsClient` class in `src/label_studio_sdk/projects/client.py` to include `id` field in `ProjectsCreateResponse` object and populate it from the response JSON
* Update `test_create` function in `tests/test_projects.py` to include `id` field in the expected response and validate it

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/HumanSignal/label-studio-sdk/pull/390?shareId=833400d4-b052-41d1-b1a6-469a56ef94c5).