### PR TITLE
fix: Updates type for `completed_by` field

### DIFF
--- a/src/label_studio_sdk/types/annotation.py
+++ b/src/label_studio_sdk/types/annotation.py
@@ -6,6 +6,7 @@ import pydantic
 import datetime as dt
 from .annotation_last_action import AnnotationLastAction
 from ..core.pydantic_utilities import IS_PYDANTIC_V2
+from .user_simple import UserSimple
 
 
 class Annotation(UniversalBaseModel):
@@ -25,7 +26,7 @@ class Annotation(UniversalBaseModel):
     Time delta from creation time
     """
 
-    completed_by: typing.Optional[int] = None
+    completed_by: typing.Optional[typing.Union[UserSimple, int]] = None
     unique_id: typing.Optional[str] = None
     was_cancelled: typing.Optional[bool] = pydantic.Field(default=None)
     """


### PR DESCRIPTION
## Problem

`Annotation` type field is currently only valid for `int` types, however API returns `dict` for `completed_by` field. Dictionary returned by API can't be used directly with `Annotation` object.

```sh
label-studio-sdk==1.0.10
pydantic==2.10.6
```

## Changes

- Added import for `UserSimple` model.
- Updated type annotation to use `typing.Union` with `int` and `UserSimple` 

## Impact

- Now direct output from API can be accepted by `Annotation` type.
- Maintains compatibility with accepting `int` type as well.


## Checked with

Simple test to validate that `dict` and `int` values are accepted by `Annotation` type for `completed_by` field.

```python

from label_studio_sdk.client import LabelStudio
from label_studio_sdk.types import Annotation

client = LabelStudio()

annotations = client.annotations.get(id=12345)
first = next(annotations)

isinstance(first.get("completed_by"), dict)
>>> True

as_int = {
    k: v for k,v in first.items() if k != "completed_by"
} | {"completed_by": 09876}

annotation_01 = Annotation(**first)
annotation_02 = Annotation(**as_int)

isinstance(annotation_01.completed_by, UserSimple)
>>> True

isinstance(annotation_02.completed_by, UserSimple)
>>> True
```

> [!NOTE]
> It appears that these might be generated from API documentation, which might mean this change might not integrate permanently if merged. Unclear to me at the moment if there is a better way to integrate a change like this into the current workflow, but it seemed like it was worthwhile to open a PR as a proposal for a QOL improvement.

