### PR TITLE
fix: LEAP-1842: Repair label-studio-converter cli

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,3 +80,6 @@ line-length = 120
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[project.scripts]
+label-studio-converter = "label_studio_sdk.converter.main:main"


### PR DESCRIPTION
- fix pyproject config to make label-studio-converter command available after package installation