### PR TITLE
fix: UTC-18: Respect users httpx client for token refresh

### DIFF
--- a/src/label_studio_sdk/core/client_wrapper.py
+++ b/src/label_studio_sdk/core/client_wrapper.py
@@ -18,7 +18,7 @@ class BaseClientWrapper:
 
         # even in the async case, refreshing access token (when the existing one is expired) should be sync
         from ..tokens.client_ext import TokensClientExt
-        self._tokens_client = TokensClientExt(base_url=base_url, api_key=api_key)
+        self._tokens_client = TokensClientExt(base_url=base_url, api_key=api_key, client_wrapper=self)
 
 
     def get_timeout(self) -> typing.Optional[float]:


### PR DESCRIPTION
Previously we were creating a new httpx client for this token refresh call, which works when LabelStudio / AsyncLabelStudio is initialized with default httpx client , but it did not respect user-provided httpx_client. 

The obvious solution is to use that same client, but that turned out to be much more complicated than it sounds. 

In the end I ended up still making a new sync httpx client, but constructed using the same params of the user-provided httpx Client/AsyncClient 