### PR TITLE
fix: Changed union typing in client_ext.py  from | operator to Union[] for compatibility with Python 3.9

### DIFF
--- a/src/label_studio_sdk/projects/exports/client_ext.py
+++ b/src/label_studio_sdk/projects/exports/client_ext.py
@@ -7,6 +7,7 @@ from .client import ExportsClient, AsyncExportsClient
 from io import BytesIO
 from label_studio_sdk.versions.client import VersionsClient, AsyncVersionsClient
 from label_studio_sdk.core.api_error import ApiError
+from typing import Union
 
 
 class ExportTimeoutError(ApiError):
@@ -45,7 +46,7 @@ def _check_status(export_snapshot, converted_format_id, status):
 
 class ExportsClientExt(ExportsClient):
     
-    def _bytestream_to_fileobj(self, bytestream: typing.Iterable[bytes] | bytes) -> typing.BinaryIO:
+    def _bytestream_to_fileobj(self, bytestream: Union[typing.Iterable[bytes], bytes]) -> typing.BinaryIO:
         buffer = BytesIO()
         if isinstance(bytestream, typing.Iterable): 
             for chunk in bytestream:
@@ -122,7 +123,7 @@ class ExportsClientExt(ExportsClient):
     
 class AsyncExportsClientExt(AsyncExportsClient):
     
-    async def _bytestream_to_fileobj(self, bytestream: typing.AsyncGenerator[bytes, None] | bytes):
+    async def _bytestream_to_fileobj(self, bytestream: Union[typing.AsyncGenerator[bytes, None], bytes]):
         """Convert bytestream to file-like object"""
         fileobj = BytesIO()
         if isinstance(bytestream, typing.AsyncGenerator):


### PR DESCRIPTION
In the current release, this package doesnt work in Python 3.9 if you try to "from label_studio_sdk import Client", because of 2 functions definitions in client_ext.py that use the | operator for union typing, a feature that only works since Python 3.10 (https://peps.python.org/pep-0604/).

I replaced the | operator for union typing with Union[] typing, in 2 instances in client_ext.py.