### PR TITLE
Fix missing export images for local storage file.

### DIFF
--- a/src/label_studio_sdk/_extensions/label_studio_tools/core/utils/io.py
+++ b/src/label_studio_sdk/_extensions/label_studio_tools/core/utils/io.py
@@ -120,6 +120,8 @@ def get_local_path(
             logger.debug(
                 f"Local Storage file path exists locally, use it as a local file: {filepath}"
             )
+            if cache_dir and download_resources:
+                shutil.copy(filepath, cache_dir)
             return filepath
 
     # try to get local directories


### PR DESCRIPTION
I've met same issue with:
https://github.com/HumanSignal/label-studio/issues/7778

For local storage file it just return the path without copy to the `cache_dir`.