### PR TITLE
fix: UTC-240: Allow empty result in predictions

### DIFF
--- a/src/label_studio_sdk/label_interface/interface.py
+++ b/src/label_studio_sdk/label_interface/interface.py
@@ -762,10 +762,6 @@ class LabelInterface:
                 errors.append(f"'{RESULT_KEY}' must be a list")
                 return errors
 
-            if not result:
-                errors.append(f"'{RESULT_KEY}' cannot be empty")
-                return errors
-
             # Validate score if present
             if 'score' in obj:
                 score = obj['score']


### PR DESCRIPTION
Having a prediction with an empty result is currently not passing the new prediction validation. However, it seems like a valid use case. For example, NER predictions, where the text does not contain any of the entities. A model may output an empty result, instead of not including the prediction at all. We can’t assume users will filter this out, and it actually might be useful to see that the model did not output something for a task. 