### PR TITLE
fix: ROOT-177: factor out version to constant and update it

### DIFF
--- a/src/label_studio_sdk/core/client_wrapper.py
+++ b/src/label_studio_sdk/core/client_wrapper.py
@@ -4,6 +4,7 @@ import httpx
 
 from .http_client import AsyncHttpClient, HttpClient
 
+VERSION = "2.0.6"
 
 class BaseClientWrapper:
     def __init__(
@@ -33,7 +34,7 @@ class BaseClientWrapper:
         headers: typing.Dict[str, str] = {
             "X-Fern-Language": "Python",
             "X-Fern-SDK-Name": "label-studio-sdk",
-            "X-Fern-SDK-Version": "1.0.11",
+            "X-Fern-SDK-Version": VERSION,
         }
         if self._tokens_client._use_legacy_token:
             headers["Authorization"] = f"Token {self._tokens_client.api_key}"


### PR DESCRIPTION
Because client_wrapper was added to .fernignore when we added the new-style tokens, this version string has not been being updated when the SDK is regenerated. Factor it out to a constant and update it; we need to automate this process with the release going forward