### PR TITLE
fix: UTC-312: Prompts evaluations getting stuck

### DIFF
--- a/src/label_studio_sdk/label_interface/control_tags.py
+++ b/src/label_studio_sdk/label_interface/control_tags.py
@@ -573,7 +573,7 @@ class LabelsTag(ControlTag):
             "type": "array",
             "items": {
                 "type": "object",
-                "required": ["labels"],
+                "required": ["start", "end", "labels"],
                 "properties": {
                     "start": {
                         "oneOf": [
@@ -783,7 +783,7 @@ class VideoRectangleTag(ControlTag):
     
     
 class NumberValue(BaseModel):
-    number: int = Field(..., ge=0)
+    number: float = Field(..., ge=0)
     
 
 class NumberTag(ControlTag):


### PR DESCRIPTION
Needed to add back "start" and "end" to required fields for LabelsTag 
Confirmed fix from yesterday still works regarding LabelsTag with float start/end 

Also fixed NumberTag - we allow floats in these fields, but model here was set to only accept int - did not match the reality and caused issues when saving prediction with float number value e.g. 1.5 