### PR TITLE
fix: BROS-494: Fix <Chat> predictions validation logic

### DIFF
--- a/src/label_studio_sdk/label_interface/control_tags.py
+++ b/src/label_studio_sdk/label_interface/control_tags.py
@@ -986,7 +986,8 @@ class ChatMessageTag(ControlTag):
                         "role": {"type": "string"},
                         "content": {"type": "string"},
                         "createdAt": {"type": "number"}
-                    }
+                    },
+                    "additionalProperties": True
                 }
             },
             "description": f"Chat message for {self.to_name[0]}"


### PR DESCRIPTION
Extend the fields in `chatmessage` to support more message types (e.g. tools)