### PR TITLE
fix: add dynamic version to pyproject.toml for PEP 621 and `uv` compliance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [project]
 name = "label-studio-sdk"
+dynamic = ["version"]
 
 [tool.poetry]
 name = "label-studio-sdk"


### PR DESCRIPTION
closes #663 

When using `uv` to install `label-studio-ml-backends`, it would give an error: 
```sh
$ git clone https://github.com/HumanSignal/label-studio-ml-backend.git
$ cd label-studio-ml-backend/
$ uv venv # create an uv env
$ uv pip install -e .
...error message...
`pyproject.toml` is using the `[project]` table, but the required
  `project.version` field is neither set nor present in the
  `project.dynamic` list
```

With the addition in this PR it 
1. Ensures PEP compliance
2. People can use `uv` with `label-studio-ml-backends`. 