### PR TITLE
Sdk renaming consistency

### DIFF
--- a/src/label_studio_sdk/label_interface/control_tags.py
+++ b/src/label_studio_sdk/label_interface/control_tags.py
@@ -41,7 +41,7 @@ _TAG_TO_CLASS = {
     "textarea": "TextAreaTag",
     "timeserieslabels": "TimeSeriesLabelsTag",
     "chatmessage": "ChatMessageTag",
-    "custominterface": "CustomInterfaceTag",
+    "react": "ReactTag",
 }
 
 
@@ -1126,14 +1126,14 @@ class TimeSeriesLabelsTag(ControlTag):
     _value_class: Type[TimeSeriesValue] = TimeSeriesValue
 
 
-class CustomInterfaceValue(BaseModel):
-    custominterface: Dict[str, Any]
+class ReactValue(BaseModel):
+    react: Dict[str, Any]
 
-class CustomInterfaceTag(ControlTag):
+class ReactTag(ControlTag):
     """ """
-    tag: str = "CustomInterface"
-    _value_class: Type[CustomInterfaceValue] = CustomInterfaceValue
-    _label_attr_name: str = "custominterface"
+    tag: str = "React"
+    _value_class: Type[ReactValue] = ReactValue
+    _label_attr_name: str = "react"
 
     # Registry of type aliases that can be used in outputs specification
     # Each alias maps to a function that takes arguments and returns a JSON schema fragment
@@ -1282,7 +1282,7 @@ class CustomInterfaceTag(ControlTag):
 
     def to_json_schema(self):
         """
-        Converts the current CustomInterfaceTag instance into a JSON Schema.
+        Converts the current ReactTag instance into a JSON Schema.
         
         Supports multiple parsing strategies (mutually compatible):
         
@@ -1327,5 +1327,5 @@ class CustomInterfaceTag(ControlTag):
         return {"type": "object", "properties": properties}
 
     def label(self, *args, **kwargs) -> Region:
-        value = CustomInterfaceValue(custominterface=kwargs)
+        value = ReactValue(react=kwargs)
         return Region(from_tag=self, to_tag=self, value=value)

--- a/tests/custom/test_interface/test_json_schema.py
+++ b/tests/custom/test_interface/test_json_schema.py
@@ -267,11 +267,11 @@ from label_studio_sdk._extensions.label_studio_tools.core.utils.json_schema impo
         {"sentiment": "Positive", "reasoning": "Let's think step by step"},
         {"sentiment": "Positive", "reasoning": "Let's think step by step"}
     ),
-    # custom interface with simple comma-delimited outputs
+    # React with simple comma-delimited outputs
     (
         """
         <View>
-          <CustomInterface name="my_app" toName="my_app" data="$my_data" outputs="field1,field2,field3" />
+          <React name="my_app" toName="my_app" data="$my_data" outputs="field1,field2,field3" />
         </View>
         """,
         {
@@ -573,11 +573,11 @@ def test_concurrent_json_schema_to_pydantic_threaded():
     "mixed_delimited_with_aliases",
     "pipe_with_rating",
 ])
-def test_custom_interface_outputs_parsing(outputs_attr, expected_properties, sample_input):
-    """Test various parsing strategies for CustomInterface outputs attribute."""
+def test_react_outputs_parsing(outputs_attr, expected_properties, sample_input):
+    """Test various parsing strategies for React outputs attribute."""
     config = f'''
     <View>
-      <CustomInterface name="result" toName="result" outputs="{outputs_attr}" />
+      <React name="result" toName="result" outputs="{outputs_attr}" />
     </View>
     '''
     interface = LabelInterface(config)

--- a/tests/custom/test_interface/test_lpi.py
+++ b/tests/custom/test_interface/test_lpi.py
@@ -1,6 +1,6 @@
 from label_studio_sdk.label_interface.region import Region
 from label_studio_sdk.label_interface.object_tags import ImageTag
-from label_studio_sdk.label_interface.control_tags import RectangleTag, CustomInterfaceTag
+from label_studio_sdk.label_interface.control_tags import RectangleTag, ReactTag
 
 
 def test_li():
@@ -26,21 +26,21 @@ def test_find_tags_by_class():
     - Creating a LabelInterface with multiple tag types
     - Using find_tags_by_class to filter tags by their class
     - Verifying that only tags of the specified class are returned
-    - Ensuring the method works with CustomInterfaceTag
+    - Ensuring the method works with ReactTag
     """
     from label_studio_sdk.label_interface import LabelInterface
     
-    # Setup: Create a config with multiple tag types including CustomInterface
+    # Setup: Create a config with multiple tag types including React
     config = """
     <View>
         <Image name="img" value="$image"/>
         <Rectangle name="rect" toName="img"/>
-        <CustomInterface name="custom1" toName="custom1" value="$my_data1" outputs="field1, field2" />
-        <CustomInterface name="custom2" toName="custom2" value="$my_data2" outputs="field3, field4"><![CDATA[
+        <React name="custom1" toName="custom1" value="$my_data1" outputs="field1, field2" />
+        <React name="custom2" toName="custom2" value="$my_data2" outputs="field3, field4"><![CDATA[
         function MyInterface({ React, addRegion, regions, data }) {
           return React.createElement('div', {}, 'content');
         }
-        ]]></CustomInterface>
+        ]]></React>
         <Choices name="choice" toName="img">
             <Choice value="option1"/>
             <Choice value="option2"/>
@@ -51,15 +51,15 @@ def test_find_tags_by_class():
     # Action: Parse the config and find tags by class
     li = LabelInterface(config)
     
-    # Validation: Find all CustomInterfaceTag instances
-    custom_tags = li.find_tags_by_class(CustomInterfaceTag)
+    # Validation: Find all ReactTag instances
+    custom_tags = li.find_tags_by_class(ReactTag)
     
-    # Verify we found exactly 2 CustomInterface tags
-    assert len(custom_tags) == 2, f"Expected 2 CustomInterface tags, found {len(custom_tags)}"
+    # Verify we found exactly 2 React tags
+    assert len(custom_tags) == 2, f"Expected 2 React tags, found {len(custom_tags)}"
     
-    # Verify all returned tags are CustomInterfaceTag instances
+    # Verify all returned tags are ReactTag instances
     for tag in custom_tags:
-        assert isinstance(tag, CustomInterfaceTag), f"Expected CustomInterfaceTag, got {type(tag)}"
+        assert isinstance(tag, ReactTag), f"Expected ReactTag, got {type(tag)}"
     
     # Verify the names match
     tag_names = [tag.name for tag in custom_tags]


### PR DESCRIPTION
Rename `CustomInterface` to `React` to ensure consistency with the main Label Studio repository.

---
[Slack Thread](https://humansignal.slack.com/archives/D09B73SGE7R/p1766714505648789?thread_ts=1766714505.648789&cid=D09B73SGE7R)

<a href="https://cursor.com/background-agent?bcId=bc-cd81b21e-bbce-4233-b665-564fb4b1ccab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cd81b21e-bbce-4233-b665-564fb4b1ccab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

