### PR TITLE
fix: FIT-1165: SDK using PATs cannot handle trailing slashes in base_url

### DIFF
--- a/src/label_studio_sdk/tokens/client_ext.py
+++ b/src/label_studio_sdk/tokens/client_ext.py
@@ -1,4 +1,5 @@
 import threading
+import urllib.parse
 import typing
 from datetime import datetime, timezone
 import ssl
@@ -117,7 +118,7 @@ class TokensClientExt:
         if isinstance(existing_client, httpx.Client):
             response = existing_client.request(
                 method="POST",
-                url=f"{self._base_url}/api/token/refresh/",
+                url=urllib.parse.urljoin(f"{self._base_url}", "api/token/refresh/"),
                 json={"refresh": self._api_key},
                 headers={"Content-Type": "application/json"},
             )
@@ -128,7 +129,7 @@ class TokensClientExt:
             with httpx.Client(**client_params) as sync_client:
                 response = sync_client.request(
                     method="POST",
-                    url=f"{self._base_url}/api/token/refresh/",
+                    url=urllib.parse.urljoin(f"{self._base_url}/", "api/token/refresh/"),
                     json={"refresh": self._api_key},
                     headers={"Content-Type": "application/json"},
                 )


### PR DESCRIPTION
refresh url was not built properly, leading to `base_url//api/token/refresh` in some cases, which is handled gracefully by local LSE but not our hosted deployments. Now matches how other parts of the SDK build the url.