### PR TITLE
Fix: Windows path backslash issue in COCO to LabelStudio path conversion

### DIFF
--- a/src/label_studio_sdk/converter/imports/coco.py
+++ b/src/label_studio_sdk/converter/imports/coco.py
@@ -22,7 +22,7 @@ def new_task(out_type, root_url, file_name):
         dict: Label Studio task structure with image data and empty result array
     """
     return {
-        "data": {"image": os.path.join(root_url, file_name)},
+        "data": {"image": root_url + file_name},
         # 'annotations' or 'predictions'
         out_type: [
             {


### PR DESCRIPTION
What is the problem?
原代码中使用 os.path.join(root_url, file_name) 拼接 LabelStudio 本地文件路径（root_url 通常为 /data/local-files/?d=）时，在 Windows 系统下会自动将路径分隔符转为反斜杠 \，导致生成的路径如 /data/local-files/?d\images/test.jpg 不符合 URL 规范，LabelStudio 无法正确解析该路径。
What is the solution?
由于 COCO 数据集的 file_name 字段始终采用正斜杠 / 风格的路径格式，因此将路径拼接方式从 os.path.join 替换为直接字符串拼接（root_url + file_name）： 避免 Windows 系统下反斜杠的生成，保证路径符合 URL 规范；
保留 root_url 中的查询参数 ?d=（相比 urllib.parse.urljoin 不会丢失该参数）； 数据源格式稳定（COCO 始终为正斜杠），直接拼接足够可靠且无额外复杂度。
How was this tested?
验证环境：Windows 10 + Python 3.12 + LabelStudio 1.22.x测试场景及结果： 测试 COCO 标准路径：root_url="/data/local-files/?d=" + file_name="val2017/000000123456.jpg" → 生成 /data/local-files/?d=val2017/000000123456.jpg，LabelStudio 可正常加载图片； 测试 Windows 下路径输入：即使传入带反斜杠的 file_name（非 COCO 场景），因 COCO 数据源本身为正斜杠，无兼容性问题； 对比原逻辑：原 os.path.join 生成 /data/local-files/?d\val2017/000000123456.jpg，LabelStudio 解析失败；修改后路径解析正常。 Additional context (可选，补充说明)
不使用 urllib.parse.urljoin 的原因：该方法会按标准 URL 规则解析，导致 root_url 中的 ?d= 查询参数丢失，不符合 LabelStudio 本地文件路径的拼接逻辑； 该修改仅影响 COCO 转 LabelStudio 的路径拼接逻辑，无其他功能侧的副作用。