### PR TITLE
feat: Add interface pull and draft sync support

### DIFF
--- a/interface-cli.md
+++ b/interface-cli.md
@@ -39,16 +39,23 @@ cd sentiment-interface
 Validate the interface statically and run its browser scenario:
 
 ```bash
-label-studio-sdk interface validate Screen.jsx --scenario scenarios.js
+label-studio-sdk interface validate .
 ```
 
 Open the live playground and sync local file changes as you edit:
 
 ```bash
-label-studio-sdk interface preview Screen.jsx --task task.json
+label-studio-sdk interface preview .
 ```
 
-Create or update a saved interface in Label Studio:
+Pull an existing interface and continue locally:
+
+```bash
+label-studio-sdk interface pull --id 73 ./existing-interface
+cd existing-interface
+```
+
+Create or update a saved interface in Label Studio. By default, this creates a local draft version:
 
 ```bash
 label-studio-sdk interface sync Screen.jsx \
@@ -59,7 +66,7 @@ label-studio-sdk interface sync Screen.jsx \
 Create a project that uses the synced interface:
 
 ```bash
-label-studio-sdk interface start Screen.jsx \
+label-studio-sdk interface start . \
   --project-title "Sentiment Review Project" \
   --workspace 3
 ```
@@ -137,6 +144,7 @@ Without `--force`, the command refuses to overwrite existing scaffold files.
 Run offline validation.
 
 ```bash
+label-studio-sdk interface validate ./my-interface
 label-studio-sdk interface validate Screen.jsx
 label-studio-sdk interface validate Screen.jsx --scenario scenarios.js
 label-studio-sdk interface validate Screen.jsx --json
@@ -190,20 +198,22 @@ The scenario context includes:
 Open the Label Studio interface playground and live-sync source changes.
 
 ```bash
+label-studio-sdk interface preview ./my-interface
 label-studio-sdk interface preview Screen.jsx --task task.json
 label-studio-sdk interface preview Screen.jsx --task task.json --no-open
 label-studio-sdk interface preview Screen.jsx --lse-url http://localhost:8080
 ```
 
-`preview` starts a local file watcher. On each save, it pushes the current source to the playground session. The initial push can include task data from `--task`; later pushes update only the code.
+`preview` starts a local file watcher. Pass a directory to use the scaffolded bundle defaults: `Screen.jsx` for the interface and `task.json` or `sample.json` for example task data. On each save, it pushes the current source to the playground session. The initial push can include task data from `--task` or the bundle's task-data file; later source saves update the code, and task-data saves update the task.
 
 ### `sync`
 
-Create or update a saved interface.
+Create or update a saved interface. `sync` creates an unpublished local draft by default so you can review it in Label Studio before publishing.
 
 ```bash
 label-studio-sdk interface sync Screen.jsx --title "Review UI"
 label-studio-sdk interface sync Screen.jsx --id 12 --message "Tighten parser"
+label-studio-sdk interface sync Screen.jsx --id 12 --publish
 label-studio-sdk interface sync Screen.jsx --workspace-title "Data Science"
 label-studio-sdk interface sync Screen.jsx --dry-run
 ```
@@ -213,6 +223,7 @@ By default, `sync`:
 - validates and compiles the file
 - creates a new interface when no id or sidecar entry exists
 - updates the existing interface when `--id` or a sidecar entry is available
+- appends a new draft version without replacing existing versions
 - skips upload when the local source hash has not changed
 - writes a sidecar file next to the JSX source
 
@@ -222,10 +233,23 @@ Useful options:
 - `--title`: set the interface title.
 - `--workspace`: use a workspace id for newly created interfaces.
 - `--workspace-title`: resolve a workspace by exact title.
+- `--publish`: create a published version instead of a local draft.
 - `--no-validate`: skip the validation gate, while still requiring successful compilation.
 - `--force`: upload even when hashes match.
 - `--dry-run`: print the planned action without writing to the server.
 - `--message`: store a history message for the synced version.
+
+### `pull`
+
+Pull a saved interface into a local bundle.
+
+```bash
+label-studio-sdk interface pull --id 12 ./review-ui
+label-studio-sdk interface pull --id 12 --version 4 ./review-ui
+label-studio-sdk interface pull --id 12 ./review-ui --force
+```
+
+`pull` writes `Screen.jsx`, `task.json`, optional `params.json` defaults from `paramsSchema`, and a sidecar file. Without `--version`, it pulls the latest version, including local drafts.
 
 ### `start`
 
@@ -237,7 +261,8 @@ label-studio-sdk interface start Screen.jsx \
   --params params.json
 ```
 
-`--params` must point to a JSON file. The JSON is saved as the project interface params and is passed into the component as `params`.
+`start` syncs a published version so the new project can safely reference it. `--params` must point to a JSON file. The JSON is saved as the project interface params and is passed into the component as `params`.
+When you pass a directory, `start` uses `Screen.jsx` for the interface and `params.json` for project params when present.
 
 Useful options:
 
@@ -274,7 +299,7 @@ The command checks Node.js, npm, the API token, validator dependency installatio
 
 ## Sidecar Files
 
-After a successful `sync`, the CLI writes a sidecar next to the source file:
+After a successful `sync` or `pull`, the CLI writes a sidecar next to the source file:
 
 ```text
 Screen.jsx.ls-interface.json
@@ -289,7 +314,7 @@ The sidecar is keyed by Label Studio base URL and stores:
 - last pushed source hash
 - last pushed timestamp
 
-This lets future `sync`, `start`, and `open` commands find the saved interface without requiring `--id`.
+This lets future `sync`, `start`, and `open` commands find the saved interface without requiring `--id`. A sidecar source version can point at a draft version until you publish it.
 
 ## Auth and URL Resolution
 

--- a/src/label_studio_sdk/_extensions/interface/cli.py
+++ b/src/label_studio_sdk/_extensions/interface/cli.py
@@ -19,12 +19,17 @@ from typing import Any
 
 import appdirs
 import httpx
+import jwt
 import typer
 
 SIDECAR_SUFFIX = ".ls-interface.json"
 DEFAULT_BASE_URL = "https://app.humansignal.com"
 VALIDATOR_PACKAGE = "label_studio_sdk._extensions.interface.validator"
 VALIDATOR_ASSETS = ("package.json", "package-lock.json", "validate.mjs", "scenario-runner.mjs")
+INTERFACE_FILE_CANDIDATES = ("Screen.jsx", "Interface.jsx", "interface.jsx", "index.jsx")
+TASK_FILE_CANDIDATES = ("task.json", "sample.json", "example-task.json", "example_task.json")
+SCENARIO_FILE_CANDIDATES = ("scenarios.js", "scenario.js")
+PARAMS_FILE_CANDIDATES = ("params.json", "parameters.json")
 
 app = typer.Typer(
     help="Develop Label Studio custom interfaces.",
@@ -47,6 +52,10 @@ class SyncResult:
         return f"{self.base_url}/interfaces/{self.interface_id}/overview"
 
 
+def _is_record(value: Any) -> bool:
+    return isinstance(value, dict)
+
+
 def _context_obj(ctx: typer.Context | None) -> dict[str, Any]:
     current = ctx
     while current is not None:
@@ -59,11 +68,7 @@ def _context_obj(ctx: typer.Context | None) -> dict[str, Any]:
 def _resolve_base_url(ctx: typer.Context | None, explicit: str | None = None) -> str:
     ctx_obj = _context_obj(ctx)
     return (
-        explicit
-        or ctx_obj.get("base_url")
-        or os.getenv("LABEL_STUDIO_URL")
-        or os.getenv("LS_URL")
-        or DEFAULT_BASE_URL
+        explicit or ctx_obj.get("base_url") or os.getenv("LABEL_STUDIO_URL") or os.getenv("LS_URL") or DEFAULT_BASE_URL
     ).rstrip("/")
 
 
@@ -72,8 +77,46 @@ def _resolve_token(ctx: typer.Context | None, explicit: str | None = None) -> st
     return explicit or ctx_obj.get("api_key") or os.getenv("LABEL_STUDIO_API_KEY")
 
 
-def _auth_headers(token: str) -> dict[str, str]:
-    scheme = "Bearer" if token.count(".") == 2 else "Token"
+def _jwt_claims(token: str) -> dict[str, Any] | None:
+    if token.count(".") != 2:
+        return None
+    try:
+        claims = jwt.decode(token, options={"verify_signature": False, "verify_exp": False})
+    except jwt.InvalidTokenError:
+        return None
+    return claims if isinstance(claims, dict) else None
+
+
+def _refresh_access_token(base_url: str, refresh_token: str) -> str:
+    with httpx.Client(timeout=30.0) as client:
+        try:
+            response = client.post(
+                f"{base_url}/api/token/refresh/",
+                json={"refresh": refresh_token},
+                headers={"Content-Type": "application/json"},
+            )
+            response.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            _surface_http_error(exc)
+            raise typer.Exit(code=1) from None
+        except httpx.HTTPError as exc:
+            typer.echo(f"error: failed to refresh API token: {exc}", err=True)
+            raise typer.Exit(code=1) from None
+
+    data = response.json()
+    access_token = data.get("access") if isinstance(data, dict) else None
+    if not isinstance(access_token, str) or not access_token:
+        typer.echo("error: token refresh response did not include an access token", err=True)
+        raise typer.Exit(code=1)
+    return access_token
+
+
+def _auth_headers(token: str, *, base_url: str | None = None) -> dict[str, str]:
+    claims = _jwt_claims(token)
+    if base_url is not None and claims and claims.get("token_type") == "refresh":
+        token = _refresh_access_token(base_url, token)
+        claims = _jwt_claims(token)
+    scheme = "Bearer" if claims else "Token"
     return {"Authorization": f"{scheme} {token}"}
 
 
@@ -96,6 +139,49 @@ def _load_task(task_path: Path | None) -> dict[str, Any] | None:
         typer.echo("error: --task must decode to a JSON object", err=True)
         raise typer.Exit(code=2)
     return task
+
+
+def _resolve_bundle_file(
+    bundle: Path,
+    explicit: Path | None,
+    candidates: tuple[str, ...],
+) -> Path | None:
+    if explicit is not None or not bundle.is_dir():
+        return explicit
+    for name in candidates:
+        candidate = bundle / name
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _resolve_interface_file(path: Path) -> Path:
+    if path.is_file():
+        return path
+    if not path.is_dir():
+        typer.echo(f"error: interface path does not exist: {path}", err=True)
+        raise typer.Exit(code=2)
+
+    for name in INTERFACE_FILE_CANDIDATES:
+        candidate = path / name
+        if candidate.is_file():
+            return candidate
+
+    jsx_files = sorted(candidate for candidate in path.glob("*.jsx") if candidate.is_file())
+    if len(jsx_files) == 1:
+        return jsx_files[0]
+    if jsx_files:
+        names = ", ".join(candidate.name for candidate in jsx_files)
+        expected = ", ".join(INTERFACE_FILE_CANDIDATES)
+        typer.echo(
+            f"error: multiple JSX files in {path}: {names}. Rename one to one of: {expected}",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+
+    expected = ", ".join(INTERFACE_FILE_CANDIDATES)
+    typer.echo(f"error: no interface file found in {path}. Expected one of: {expected}", err=True)
+    raise typer.Exit(code=2)
 
 
 def _post_preview(client: httpx.Client, push_url: str, *, code: str, task: dict[str, Any] | None) -> bool:
@@ -298,7 +384,9 @@ def _resolve_workspace(
         raise typer.Exit(code=2)
     if len(matches) > 1:
         ids = ", ".join(str(workspace.get("id")) for workspace in matches)
-        typer.echo(f'error: multiple workspaces titled "{workspace_title}" (ids: {ids}). Pass --workspace ID.', err=True)
+        typer.echo(
+            f'error: multiple workspaces titled "{workspace_title}" (ids: {ids}). Pass --workspace ID.', err=True
+        )
         raise typer.Exit(code=2)
     return matches[0].get("id")
 
@@ -315,7 +403,9 @@ def _surface_http_error(exc: httpx.HTTPStatusError) -> None:
 def _prepare_source(file: Path, *, no_validate: bool) -> tuple[str, str, str, dict[str, Any]]:
     report = _run_validator(file)
     if not no_validate and not report.get("ok"):
-        typer.echo(typer.style(f"FAIL {file.name} invalid; refusing to sync.", fg=typer.colors.RED, bold=True), err=True)
+        typer.echo(
+            typer.style(f"FAIL {file.name} invalid; refusing to sync.", fg=typer.colors.RED, bold=True), err=True
+        )
         for entry in report.get("errors") or []:
             typer.echo(f"  error [{entry.get('stage', '?')}]: {entry.get('message', '')}", err=True)
         raise typer.Exit(code=1)
@@ -328,17 +418,20 @@ def _prepare_source(file: Path, *, no_validate: bool) -> tuple[str, str, str, di
         raise typer.Exit(code=1)
 
     source = file.read_text(encoding="utf-8").rstrip()
-    source_hash = hashlib.sha256(source.encode("utf-8")).hexdigest()
+    source_hash = _source_hash(source)
     return source, compiled, source_hash, report
 
 
-def _new_version(source: str, compiled: str, report: dict[str, Any]) -> dict[str, Any]:
+def _new_version(source: str, compiled: str, report: dict[str, Any], *, publish: bool) -> dict[str, Any]:
     metadata = report.get("metadata") or {}
     version = {
         "code": source,
         "compiled": compiled,
         "createdAt": datetime.now(timezone.utc).isoformat(),
+        "op": "api_push",
     }
+    if not publish:
+        version["unpublished"] = True
     for report_key, version_key in (
         ("inputSchema", "inputSchema"),
         ("outputSchema", "outputSchema"),
@@ -350,7 +443,53 @@ def _new_version(source: str, compiled: str, report: dict[str, Any]) -> dict[str
     return version
 
 
-def _build_history_entry(file: Path, source: str, compiled: str, message: str | None) -> tuple[dict[str, Any], dict[str, Any]]:
+def _append_version_payload(version: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in version.items() if key not in {"id", "createdAt", "createdBy"}}
+
+
+def _source_hash(source: str) -> str:
+    return hashlib.sha256(source.rstrip().encode("utf-8")).hexdigest()
+
+
+def _version_id(version: dict[str, Any], index: int) -> int:
+    value = version.get("id")
+    if isinstance(value, int) and value >= 0 and not isinstance(value, bool):
+        return value
+    return index
+
+
+def _find_version(versions: list[dict[str, Any]], version_id: int | None) -> tuple[int, dict[str, Any]] | None:
+    if not versions:
+        return None
+    if version_id is None:
+        index = len(versions) - 1
+        return _version_id(versions[index], index), versions[index]
+    for index, version in enumerate(versions):
+        if _version_id(version, index) == version_id:
+            return version_id, version
+    return None
+
+
+def _latest_version_id(versions: list[dict[str, Any]]) -> int | None:
+    if not versions:
+        return None
+    return _version_id(versions[-1], len(versions) - 1)
+
+
+def _latest_published_version_id_for_source(versions: list[dict[str, Any]], source_hash: str) -> int | None:
+    for index in range(len(versions) - 1, -1, -1):
+        version = versions[index]
+        if not _is_record(version) or version.get("unpublished"):
+            continue
+        code = version.get("code")
+        if isinstance(code, str) and _source_hash(code) == source_hash:
+            return _version_id(version, index)
+    return None
+
+
+def _build_history_entry(
+    file: Path, source: str, compiled: str, message: str | None
+) -> tuple[dict[str, Any], dict[str, Any]]:
     now_iso = datetime.now(timezone.utc).isoformat()
     message_id = str(uuid.uuid4())
     content = message or "Synced via label-studio-sdk interface CLI"
@@ -388,6 +527,28 @@ def _interface_schema_payload(report: dict[str, Any]) -> dict[str, Any]:
     return payload
 
 
+def _schema_defaults(schema: Any) -> dict[str, Any]:
+    if not _is_record(schema) or not _is_record(schema.get("properties")):
+        return {}
+    defaults: dict[str, Any] = {}
+    for key, value in schema["properties"].items():
+        if _is_record(value) and "default" in value:
+            defaults[key] = value["default"]
+    return defaults
+
+
+def _write_bundle_file(path: Path, contents: str, *, force: bool) -> None:
+    if path.exists() and not force:
+        typer.echo(f"error: refusing to overwrite {path}. Use --force to overwrite.", err=True)
+        raise typer.Exit(code=2)
+    path.write_text(contents, encoding="utf-8")
+    typer.echo(f"wrote {path}")
+
+
+def _json_file_contents(value: Any) -> str:
+    return json.dumps(value, indent=2, sort_keys=True) + "\n"
+
+
 def _sync_interface(
     *,
     ctx: typer.Context | None,
@@ -402,6 +563,7 @@ def _sync_interface(
     force: bool,
     dry_run: bool,
     message: str | None,
+    publish: bool,
 ) -> SyncResult | None:
     resolved_token = _resolve_token(ctx, token)
     if not resolved_token:
@@ -423,7 +585,13 @@ def _sync_interface(
 
     chosen_title = title or (sidecar_entry or {}).get("title") or _default_title(file)
     action = "create" if target_id is None else "update"
-    if not force and target_id is not None and sidecar_entry and sidecar_entry.get("last_pushed_hash") == source_hash:
+    if (
+        not publish
+        and not force
+        and target_id is not None
+        and sidecar_entry
+        and sidecar_entry.get("last_pushed_hash") == source_hash
+    ):
         action = "skip"
 
     if dry_run:
@@ -438,6 +606,7 @@ def _sync_interface(
                     "workspace": workspace_id,
                     "workspace_title": workspace_title,
                     "source_hash": source_hash,
+                    "publish": publish,
                 },
                 indent=2,
             )
@@ -456,8 +625,8 @@ def _sync_interface(
             workspace_id=(sidecar_entry or {}).get("workspace"),
         )
 
-    headers = _auth_headers(resolved_token)
-    new_version = _new_version(source, compiled, report)
+    headers = _auth_headers(resolved_token, base_url=base)
+    new_version = _new_version(source, compiled, report, publish=publish)
     history_message, artifact = _build_history_entry(file, source, compiled, message)
     schema_payload = _interface_schema_payload(report)
 
@@ -467,26 +636,44 @@ def _sync_interface(
                 existing_resp = client.get(f"{base}/api/interfaces/{target_id}/")
                 existing_resp.raise_for_status()
                 existing = existing_resp.json()
-                if not force:
-                    existing_hash = hashlib.sha256((existing.get("code") or "").encode("utf-8")).hexdigest()
-                    if existing_hash == source_hash:
-                        typer.echo(f"no changes vs interface #{target_id}, skipping. Use --force to sync anyway.")
-                        return SyncResult(
-                            interface_id=target_id,
-                            title=existing.get("title") or chosen_title,
-                            status="skipped",
-                            base_url=base,
-                            source_hash=source_hash,
-                            source_version=(sidecar_entry or {}).get("source_version"),
-                            workspace_id=existing.get("workspace"),
-                        )
-
                 prev_versions = existing.get("versions") or []
-                source_version = len(prev_versions)
+                if not force:
+                    existing_hash = _source_hash(existing.get("code") or "")
+                    if existing_hash == source_hash:
+                        if publish:
+                            published_source_version = _latest_published_version_id_for_source(
+                                prev_versions, source_hash
+                            )
+                            if published_source_version is not None:
+                                typer.echo(
+                                    f"no changes vs published interface #{target_id}, skipping. "
+                                    "Use --force to sync anyway."
+                                )
+                                return SyncResult(
+                                    interface_id=target_id,
+                                    title=existing.get("title") or chosen_title,
+                                    status="skipped",
+                                    base_url=base,
+                                    source_hash=source_hash,
+                                    source_version=published_source_version,
+                                    workspace_id=existing.get("workspace"),
+                                )
+                        else:
+                            typer.echo(f"no changes vs interface #{target_id}, skipping. Use --force to sync anyway.")
+                            return SyncResult(
+                                interface_id=target_id,
+                                title=existing.get("title") or chosen_title,
+                                status="skipped",
+                                base_url=base,
+                                source_hash=source_hash,
+                                source_version=(sidecar_entry or {}).get("source_version"),
+                                workspace_id=existing.get("workspace"),
+                            )
+
                 payload: dict[str, Any] = {
                     "code": source,
                     "compiled": compiled,
-                    "versions": [*prev_versions, new_version],
+                    "versions": [_append_version_payload(new_version)],
                     "messages": [*(existing.get("messages") or []), history_message],
                     "artifacts": [*(existing.get("artifacts") or []), artifact],
                 }
@@ -495,11 +682,14 @@ def _sync_interface(
                 payload.update({key: value for key, value in schema_payload.items() if key != "metadata"})
                 if schema_payload.get("metadata"):
                     payload["metadata"] = {**(existing.get("metadata") or {}), **schema_payload["metadata"]}
-                resp = client.patch(f"{base}/api/interfaces/{target_id}/", json=payload)
+                resp = client.post(f"{base}/api/interfaces/{target_id}/append_versions/", json=payload)
                 resp.raise_for_status()
                 data = resp.json()
+                source_version = _latest_version_id(data.get("versions") or prev_versions)
                 status = "updated"
-                typer.echo(typer.style(f"updated interface #{data['id']} ({data.get('title', '')})", fg=typer.colors.GREEN))
+                typer.echo(
+                    typer.style(f"updated interface #{data['id']} ({data.get('title', '')})", fg=typer.colors.GREEN)
+                )
             else:
                 resolved_workspace_id = _resolve_workspace(client, base, workspace_id, workspace_title)
                 payload = {
@@ -550,8 +740,17 @@ def _sync_interface(
 @app.command()
 def preview(
     ctx: typer.Context,
-    file: Path = typer.Argument(..., exists=True, dir_okay=False, readable=True, help="Path to the .jsx module."),
-    task: Path | None = typer.Option(None, "--task", exists=True, dir_okay=False, readable=True, help="Task data JSON."),
+    file: Path = typer.Argument(
+        ...,
+        exists=True,
+        file_okay=True,
+        dir_okay=True,
+        readable=True,
+        help="Path to the .jsx module or interface directory.",
+    ),
+    task: Path | None = typer.Option(
+        None, "--task", exists=True, dir_okay=False, readable=True, help="Task data JSON."
+    ),
     lse_url: str | None = typer.Option(
         None,
         "--lse-url",
@@ -568,8 +767,11 @@ def preview(
         typer.echo("error: `watchfiles` is required for preview. Reinstall label-studio-sdk dependencies.", err=True)
         raise typer.Exit(code=2) from None
 
+    source_path = file
+    task = _resolve_bundle_file(source_path, task, TASK_FILE_CANDIDATES)
     task_data = _load_task(task)
-    file = file.resolve()
+    file = _resolve_interface_file(source_path).resolve()
+    task = task.resolve() if task is not None else None
     base = _resolve_base_url(ctx, lse_url)
     token = secrets.token_urlsafe(16)
     push_url = f"{base}/api/interfaces/playground/{token}/push/"
@@ -592,8 +794,13 @@ def preview(
             webbrowser.open(playground_url)
 
         try:
-            for changes in watch(file, step=200, recursive=False):
-                if not any(Path(path) == file for _, path in changes):
+            watch_paths = [file]
+            if task is not None:
+                watch_paths.append(task)
+            for changes in watch(*watch_paths, step=200, recursive=False):
+                changed_paths = {Path(path).resolve() for _, path in changes}
+                task_changed = task is not None and task in changed_paths
+                if file not in changed_paths and not task_changed:
                     continue
                 try:
                     code = file.read_text(encoding="utf-8")
@@ -601,19 +808,28 @@ def preview(
                     typer.echo(f"  read failed: {exc}", err=True)
                     continue
                 source_hash = hashlib.sha256(code.encode("utf-8")).hexdigest()
-                if source_hash == last_pushed_hash:
+                if source_hash == last_pushed_hash and not task_changed:
                     continue
+                task_update = _load_task(task) if task_changed else None
                 stamp = time.strftime("%H:%M:%S")
-                if _post_preview(client, push_url, code=code, task=None):
+                if _post_preview(client, push_url, code=code, task=task_update):
                     last_pushed_hash = source_hash
-                    typer.echo(f"  [{stamp}] pushed {len(code)} bytes")
+                    suffix = " and task data" if task_changed else ""
+                    typer.echo(f"  [{stamp}] pushed {len(code)} bytes{suffix}")
         except KeyboardInterrupt:
             typer.echo("\nbye")
 
 
 @app.command()
 def validate(
-    file: Path = typer.Argument(..., exists=True, dir_okay=False, readable=True, help="Path to the .jsx module."),
+    file: Path = typer.Argument(
+        ...,
+        exists=True,
+        file_okay=True,
+        dir_okay=True,
+        readable=True,
+        help="Path to the .jsx module or interface directory.",
+    ),
     scenario: Path | None = typer.Option(
         None,
         "--scenario",
@@ -625,6 +841,9 @@ def validate(
     as_json: bool = typer.Option(False, "--json", help="Print the raw JSON report."),
 ) -> None:
     """Validate an interface offline."""
+    source_path = file
+    scenario = _resolve_bundle_file(source_path, scenario, SCENARIO_FILE_CANDIDATES)
+    file = _resolve_interface_file(source_path)
     report = _run_validator(file)
     scenario_report = None
     if scenario is not None:
@@ -653,11 +872,20 @@ def validate(
 @app.command()
 def sync(
     ctx: typer.Context,
-    file: Path = typer.Argument(..., exists=True, dir_okay=False, readable=True, help="Path to the .jsx module."),
+    file: Path = typer.Argument(
+        ...,
+        exists=True,
+        file_okay=True,
+        dir_okay=True,
+        readable=True,
+        help="Path to the .jsx module or interface directory.",
+    ),
     interface_id: int | None = typer.Option(None, "--id", help="Existing interface id. Defaults to sidecar lookup."),
     title: str | None = typer.Option(None, "--title", help="Interface title. Defaults to the filename."),
     workspace_id: int | None = typer.Option(None, "--workspace", help="Workspace id for a newly created interface."),
-    workspace_title: str | None = typer.Option(None, "--workspace-title", help="Workspace title for a newly created interface."),
+    workspace_title: str | None = typer.Option(
+        None, "--workspace-title", help="Workspace title for a newly created interface."
+    ),
     token: str | None = typer.Option(None, "--token", envvar="LABEL_STUDIO_API_KEY", help="Label Studio API token."),
     lse_url: str | None = typer.Option(
         None,
@@ -666,12 +894,16 @@ def sync(
         envvar="LABEL_STUDIO_URL",
         help="Base URL of the Label Studio instance.",
     ),
-    no_validate: bool = typer.Option(False, "--no-validate", help="Skip validation gate; compilation is still required."),
+    no_validate: bool = typer.Option(
+        False, "--no-validate", help="Skip validation gate; compilation is still required."
+    ),
     force: bool = typer.Option(False, "--force", help="Sync even when the source hash is unchanged."),
     dry_run: bool = typer.Option(False, "--dry-run", help="Show what would happen without writing to the server."),
     message: str | None = typer.Option(None, "--message", help="History message for this synced version."),
+    publish: bool = typer.Option(False, "--publish", help="Create a published version instead of a local draft."),
 ) -> None:
     """Create or update a saved interface from a local file."""
+    file = _resolve_interface_file(file)
     _sync_interface(
         ctx=ctx,
         file=file,
@@ -685,7 +917,115 @@ def sync(
         force=force,
         dry_run=dry_run,
         message=message,
+        publish=publish,
     )
+
+
+@app.command()
+def pull(
+    ctx: typer.Context,
+    directory: Path = typer.Argument(Path("."), file_okay=False, help="Directory to write the interface bundle into."),
+    interface_id: int = typer.Option(..., "--id", help="Saved interface id."),
+    version_id: int | None = typer.Option(
+        None, "--version", min=0, help="Stable version id to pull. Defaults to the latest version."
+    ),
+    token: str | None = typer.Option(None, "--token", envvar="LABEL_STUDIO_API_KEY", help="Label Studio API token."),
+    lse_url: str | None = typer.Option(
+        None,
+        "--lse-url",
+        "--base-url",
+        envvar="LABEL_STUDIO_URL",
+        help="Base URL of the Label Studio instance.",
+    ),
+    force: bool = typer.Option(False, "--force", help="Overwrite existing local bundle files."),
+) -> None:
+    """Pull a saved interface into a local bundle."""
+    resolved_token = _resolve_token(ctx, token)
+    if not resolved_token:
+        typer.echo("error: --token or LABEL_STUDIO_API_KEY is required", err=True)
+        raise typer.Exit(code=2)
+
+    base = _resolve_base_url(ctx, lse_url)
+    headers = _auth_headers(resolved_token, base_url=base)
+    with httpx.Client(headers=headers, timeout=30.0) as client:
+        try:
+            resp = client.get(f"{base}/api/interfaces/{interface_id}/")
+            resp.raise_for_status()
+            data = resp.json()
+        except httpx.HTTPStatusError as exc:
+            _surface_http_error(exc)
+            raise typer.Exit(code=1) from None
+
+    if not _is_record(data):
+        typer.echo("error: interface API response was not a JSON object", err=True)
+        raise typer.Exit(code=1)
+
+    versions = [version for version in data.get("versions") or [] if _is_record(version)]
+    selected = _find_version(versions, version_id)
+    if selected is None and version_id is not None:
+        typer.echo(f"error: interface #{interface_id} has no version {version_id}", err=True)
+        raise typer.Exit(code=2)
+
+    source_version: int | None
+    selected_version: dict[str, Any] | None
+    if selected is None:
+        source_version = None
+        selected_version = None
+    else:
+        source_version, selected_version = selected
+
+    source = selected_version.get("code") if selected_version is not None else None
+    if not isinstance(source, str) or not source:
+        source = data.get("code")
+    if not isinstance(source, str) or not source:
+        typer.echo("error: interface response did not include source code", err=True)
+        raise typer.Exit(code=1)
+
+    params_schema = selected_version.get("paramsSchema") if selected_version is not None else None
+    if not _is_record(params_schema):
+        metadata = data.get("metadata")
+        params_schema = metadata.get("paramsSchema") if _is_record(metadata) else None
+    params_defaults = _schema_defaults(params_schema)
+
+    task_data = data.get("data_sample")
+    if not _is_record(task_data):
+        task_data = {}
+
+    directory = directory.resolve()
+    screen_path = directory / "Screen.jsx"
+    task_path = directory / "task.json"
+    params_path = directory / "params.json"
+    planned_files = [screen_path, task_path, _sidecar_path(screen_path)]
+    if params_defaults:
+        planned_files.append(params_path)
+
+    existing = [path for path in planned_files if path.exists()]
+    if existing and not force:
+        names = ", ".join(path.name for path in existing)
+        typer.echo(f"error: refusing to overwrite existing files: {names}. Use --force to overwrite.", err=True)
+        raise typer.Exit(code=2)
+
+    directory.mkdir(parents=True, exist_ok=True)
+    source_to_write = source.rstrip() + "\n"
+    _write_bundle_file(screen_path, source_to_write, force=force)
+    _write_bundle_file(task_path, _json_file_contents(task_data), force=force)
+    if params_defaults:
+        _write_bundle_file(params_path, _json_file_contents(params_defaults), force=force)
+
+    source_hash = _source_hash(source)
+    sidecar = {
+        base: {
+            "interface_id": interface_id,
+            "title": data.get("title"),
+            "workspace": data.get("workspace"),
+            "source_version": source_version,
+            "last_pushed_hash": source_hash,
+            "last_pushed_at": datetime.now(timezone.utc).isoformat(),
+        }
+    }
+    sidecar_path = _write_sidecar(screen_path, sidecar)
+    typer.echo(f"wrote {sidecar_path}")
+    typer.echo(typer.style(f"pulled interface #{interface_id} ({data.get('title', '')})", fg=typer.colors.GREEN))
 
 
 def _create_project(
@@ -724,8 +1064,17 @@ def _project_id(project: Any) -> int | None:
 @app.command()
 def start(
     ctx: typer.Context,
-    file: Path = typer.Argument(..., exists=True, dir_okay=False, readable=True, help="Path to the .jsx module."),
-    project_title: str | None = typer.Option(None, "--project-title", help="Project title. Defaults to interface title."),
+    file: Path = typer.Argument(
+        ...,
+        exists=True,
+        file_okay=True,
+        dir_okay=True,
+        readable=True,
+        help="Path to the .jsx module or interface directory.",
+    ),
+    project_title: str | None = typer.Option(
+        None, "--project-title", help="Project title. Defaults to interface title."
+    ),
     description: str = typer.Option("", "--description", help="Project description."),
     params: Path | None = typer.Option(
         None,
@@ -747,7 +1096,9 @@ def start(
         envvar="LABEL_STUDIO_URL",
         help="Base URL of the Label Studio instance.",
     ),
-    no_validate: bool = typer.Option(False, "--no-validate", help="Skip validation gate; compilation is still required."),
+    no_validate: bool = typer.Option(
+        False, "--no-validate", help="Skip validation gate; compilation is still required."
+    ),
     force: bool = typer.Option(False, "--force", help="Sync even when the source hash is unchanged."),
     no_open: bool = typer.Option(False, "--no-open", help="Do not open the created project."),
 ) -> None:
@@ -757,6 +1108,9 @@ def start(
         typer.echo("error: --token or LABEL_STUDIO_API_KEY is required", err=True)
         raise typer.Exit(code=2)
 
+    source_path = file
+    params = _resolve_bundle_file(source_path, params, PARAMS_FILE_CANDIDATES)
+    file = _resolve_interface_file(source_path)
     sync_result = _sync_interface(
         ctx=ctx,
         file=file,
@@ -770,6 +1124,7 @@ def start(
         force=force,
         dry_run=False,
         message=None,
+        publish=True,
     )
     if sync_result is None:
         raise typer.Exit(code=2)
@@ -857,9 +1212,7 @@ function parseResults(results) {
 """
 
 TASK_TEMPLATE = """{
-  "data": {
-    "text": "The interface CLI is ready to use."
-  }
+  "text": "The interface CLI is ready to use."
 }
 """
 
@@ -916,7 +1269,14 @@ def init(
 @app.command()
 def open(
     ctx: typer.Context,
-    file: Path = typer.Argument(..., exists=True, dir_okay=False, readable=True, help="Path to the .jsx module."),
+    file: Path = typer.Argument(
+        ...,
+        exists=True,
+        file_okay=True,
+        dir_okay=True,
+        readable=True,
+        help="Path to the .jsx module or interface directory.",
+    ),
     lse_url: str | None = typer.Option(
         None,
         "--lse-url",
@@ -927,6 +1287,7 @@ def open(
     no_open: bool = typer.Option(False, "--no-open", help="Only print the URL."),
 ) -> None:
     """Open the saved interface from this file's sidecar."""
+    file = _resolve_interface_file(file)
     base = _resolve_base_url(ctx, lse_url)
     sidecar_entry = _read_sidecar(file.resolve()).get(base)
     if not sidecar_entry or not sidecar_entry.get("interface_id"):

--- a/tests/custom/cli/test_interface_cli.py
+++ b/tests/custom/cli/test_interface_cli.py
@@ -1,5 +1,9 @@
+import base64
 import json
+import sys
+from copy import deepcopy
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 from typer.testing import CliRunner
@@ -8,6 +12,13 @@ from label_studio_sdk._extensions.cli.main import app as root_app
 from label_studio_sdk._extensions.interface import cli as interface_cli
 
 runner = CliRunner()
+
+
+def _jwt_token(token_type: str) -> str:
+    def encode(value: dict[str, Any]) -> str:
+        return base64.urlsafe_b64encode(json.dumps(value).encode("utf-8")).rstrip(b"=").decode("ascii")
+
+    return f"{encode({'alg': 'HS256', 'typ': 'JWT'})}.{encode({'token_type': token_type})}.{encode({'sig': True})}"
 
 
 def test_root_cli_includes_interface_group() -> None:
@@ -24,6 +35,9 @@ def test_init_scaffolds_interface_files(tmp_path: Path) -> None:
     assert (tmp_path / "Screen.jsx").exists()
     assert (tmp_path / "task.json").exists()
     assert (tmp_path / "scenarios.js").exists()
+    assert json.loads((tmp_path / "task.json").read_text(encoding="utf-8")) == {
+        "text": "The interface CLI is ready to use."
+    }
 
     second = runner.invoke(interface_cli.app, ["init", str(tmp_path)])
     assert second.exit_code == 2
@@ -44,8 +58,31 @@ class FakeResponse:
         return None
 
 
+DEFAULT_INTERFACE_PAYLOAD: dict[str, Any] = {
+    "id": 12,
+    "title": "Existing",
+    "code": "old",
+    "compiled": "compiled-old",
+    "versions": [
+        {
+            "id": 0,
+            "code": "old",
+            "compiled": "compiled-old",
+            "createdAt": "2026-01-01T00:00:00Z",
+        }
+    ],
+    "messages": [],
+    "artifacts": [],
+    "data_sample": {"text": "Existing task"},
+    "metadata": {},
+    "workspace": 3,
+}
+
+
 class FakeHttpClient:
     instances: list["FakeHttpClient"] = []
+    interface_payload: dict[str, Any] = deepcopy(DEFAULT_INTERFACE_PAYLOAD)
+    access_token: str = _jwt_token("access")
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         self.calls: list[tuple[str, str, dict[str, Any] | None]] = []
@@ -60,11 +97,57 @@ class FakeHttpClient:
 
     def get(self, url: str) -> FakeResponse:
         self.calls.append(("GET", url, None))
-        return FakeResponse({"id": 12, "title": "Existing", "code": "old", "versions": [], "messages": [], "artifacts": []})
+        return FakeResponse(deepcopy(FakeHttpClient.interface_payload))
 
     def post(self, url: str, json: dict[str, Any] | None = None, **kwargs: Any) -> FakeResponse:
         self.calls.append(("POST", url, json))
-        return FakeResponse({"id": 12, "title": json.get("title") if json else "Demo", "workspace": json.get("workspace")})
+        if url.endswith("/api/token/refresh/"):
+            return FakeResponse({"access": FakeHttpClient.access_token})
+
+        body = json or {}
+        if url.endswith("/append_versions/"):
+            existing = deepcopy(FakeHttpClient.interface_payload)
+            existing_versions = existing.get("versions") or []
+            appended_versions = [
+                {
+                    **version,
+                    "id": len(existing_versions) + index,
+                    "createdAt": "2026-01-02T00:00:00Z",
+                    "createdBy": {"id": 7, "first_name": "SDK", "last_name": "User", "email": "sdk@example.com"},
+                }
+                for index, version in enumerate(body.get("versions") or [])
+            ]
+            for field in (
+                "title",
+                "code",
+                "compiled",
+                "messages",
+                "artifacts",
+                "input_schema",
+                "output_schema",
+                "metadata",
+            ):
+                if field in body:
+                    existing[field] = body[field]
+            existing["versions"] = [*existing_versions, *appended_versions]
+            return FakeResponse(existing)
+
+        versions = [
+            {
+                **version,
+                "id": index,
+                "createdAt": version.get("createdAt", "2026-01-02T00:00:00Z"),
+            }
+            for index, version in enumerate(body.get("versions") or [])
+        ]
+        return FakeResponse(
+            {
+                "id": 12,
+                "title": body.get("title", "Demo"),
+                "workspace": body.get("workspace"),
+                "versions": versions,
+            }
+        )
 
     def patch(self, url: str, json: dict[str, Any] | None = None, **kwargs: Any) -> FakeResponse:
         self.calls.append(("PATCH", url, json))
@@ -86,10 +169,16 @@ def _validator_report() -> dict[str, Any]:
     }
 
 
+def _reset_fake_http() -> None:
+    FakeHttpClient.instances = []
+    FakeHttpClient.interface_payload = deepcopy(DEFAULT_INTERFACE_PAYLOAD)
+    FakeHttpClient.access_token = _jwt_token("access")
+
+
 def test_sync_creates_interface_and_writes_sidecar(monkeypatch: Any, tmp_path: Path) -> None:
     file = tmp_path / "Screen.jsx"
     file.write_text("({ default: function Screen() { return null; } })\n", encoding="utf-8")
-    FakeHttpClient.instances = []
+    _reset_fake_http()
     monkeypatch.setattr(interface_cli, "_run_validator", lambda _file: _validator_report())
     monkeypatch.setattr(interface_cli.httpx, "Client", FakeHttpClient)
 
@@ -120,10 +209,255 @@ def test_sync_creates_interface_and_writes_sidecar(monkeypatch: Any, tmp_path: P
     assert payload["compiled"] == "compiled-body"
     assert payload["input_schema"] == {"type": "object"}
     assert payload["metadata"]["paramsSchema"] == {"type": "object"}
+    assert payload["versions"][0]["op"] == "api_push"
+    assert payload["versions"][0]["unpublished"] is True
 
     sidecar = json.loads((tmp_path / "Screen.jsx.ls-interface.json").read_text(encoding="utf-8"))
     assert sidecar["http://ls"]["interface_id"] == 12
     assert sidecar["http://ls"]["source_version"] == 0
+
+
+def test_sync_refreshes_pat_before_interface_api(monkeypatch: Any, tmp_path: Path) -> None:
+    file = tmp_path / "Screen.jsx"
+    file.write_text("({ default: function Screen() { return null; } })\n", encoding="utf-8")
+    refresh_token = _jwt_token("refresh")
+    access_token = _jwt_token("access")
+    _reset_fake_http()
+    FakeHttpClient.access_token = access_token
+    monkeypatch.setattr(interface_cli, "_run_validator", lambda _file: _validator_report())
+    monkeypatch.setattr(interface_cli.httpx, "Client", FakeHttpClient)
+
+    result = runner.invoke(
+        interface_cli.app,
+        [
+            "sync",
+            str(file),
+            "--title",
+            "Demo",
+            "--token",
+            refresh_token,
+            "--lse-url",
+            "http://ls",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    refresh_client = FakeHttpClient.instances[0]
+    sync_client = FakeHttpClient.instances[-1]
+    assert refresh_client.calls == [("POST", "http://ls/api/token/refresh/", {"refresh": refresh_token})]
+    assert sync_client.headers == {"Authorization": f"Bearer {access_token}"}
+    assert sync_client.calls[0][1] == "http://ls/api/interfaces/"
+
+
+def test_sync_updates_interface_by_appending_local_draft(monkeypatch: Any, tmp_path: Path) -> None:
+    file = tmp_path / "Screen.jsx"
+    file.write_text("({ default: function Screen() { return <div>new</div>; } })\n", encoding="utf-8")
+    _reset_fake_http()
+    monkeypatch.setattr(interface_cli, "_run_validator", lambda _file: _validator_report())
+    monkeypatch.setattr(interface_cli.httpx, "Client", FakeHttpClient)
+
+    result = runner.invoke(
+        interface_cli.app,
+        [
+            "sync",
+            str(file),
+            "--id",
+            "12",
+            "--message",
+            "Tighten parser",
+            "--token",
+            "token",
+            "--lse-url",
+            "http://ls",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    client = FakeHttpClient.instances[-1]
+    assert client.calls[0] == ("GET", "http://ls/api/interfaces/12/", None)
+    assert client.calls[1][0] == "POST"
+    assert client.calls[1][1] == "http://ls/api/interfaces/12/append_versions/"
+    payload = client.calls[1][2]
+    assert payload is not None
+    assert payload["versions"][0]["code"] == "({ default: function Screen() { return <div>new</div>; } })"
+    assert payload["versions"][0]["unpublished"] is True
+    assert payload["versions"][0]["op"] == "api_push"
+    assert "createdAt" not in payload["versions"][0]
+    assert payload["messages"][0]["content"] == "Tighten parser"
+
+    sidecar = json.loads((tmp_path / "Screen.jsx.ls-interface.json").read_text(encoding="utf-8"))
+    assert sidecar["http://ls"]["source_version"] == 1
+
+
+def test_sync_publish_appends_published_version(monkeypatch: Any, tmp_path: Path) -> None:
+    file = tmp_path / "Screen.jsx"
+    file.write_text("({ default: function Screen() { return <div>published</div>; } })\n", encoding="utf-8")
+    _reset_fake_http()
+    monkeypatch.setattr(interface_cli, "_run_validator", lambda _file: _validator_report())
+    monkeypatch.setattr(interface_cli.httpx, "Client", FakeHttpClient)
+
+    result = runner.invoke(
+        interface_cli.app,
+        [
+            "sync",
+            str(file),
+            "--id",
+            "12",
+            "--publish",
+            "--token",
+            "token",
+            "--lse-url",
+            "http://ls",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = FakeHttpClient.instances[-1].calls[1][2]
+    assert payload is not None
+    assert "unpublished" not in payload["versions"][0]
+
+
+def test_sync_publish_does_not_skip_matching_local_draft(monkeypatch: Any, tmp_path: Path) -> None:
+    file = tmp_path / "Screen.jsx"
+    file.write_text("old\n", encoding="utf-8")
+    _reset_fake_http()
+    FakeHttpClient.interface_payload = {
+        **deepcopy(DEFAULT_INTERFACE_PAYLOAD),
+        "code": "old",
+        "versions": [
+            {
+                "id": 0,
+                "code": "old",
+                "compiled": "compiled-old",
+                "createdAt": "2026-01-01T00:00:00Z",
+                "unpublished": True,
+            }
+        ],
+    }
+    (tmp_path / "Screen.jsx.ls-interface.json").write_text(
+        json.dumps(
+            {
+                "http://ls": {
+                    "interface_id": 12,
+                    "title": "Existing",
+                    "source_version": 0,
+                    "last_pushed_hash": interface_cli._source_hash("old"),
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(interface_cli, "_run_validator", lambda _file: _validator_report())
+    monkeypatch.setattr(interface_cli.httpx, "Client", FakeHttpClient)
+
+    result = runner.invoke(
+        interface_cli.app,
+        [
+            "sync",
+            str(file),
+            "--id",
+            "12",
+            "--publish",
+            "--token",
+            "token",
+            "--lse-url",
+            "http://ls",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    client = FakeHttpClient.instances[-1]
+    assert client.calls[0][0] == "GET"
+    assert client.calls[1][1] == "http://ls/api/interfaces/12/append_versions/"
+    payload = client.calls[1][2]
+    assert payload is not None
+    assert "unpublished" not in payload["versions"][0]
+
+
+def test_pull_writes_local_bundle_and_sidecar(monkeypatch: Any, tmp_path: Path) -> None:
+    _reset_fake_http()
+    FakeHttpClient.interface_payload = {
+        **deepcopy(DEFAULT_INTERFACE_PAYLOAD),
+        "title": "Pulled Interface",
+        "code": "top-level source",
+        "data_sample": {"text": "Pulled task"},
+        "metadata": {
+            "paramsSchema": {
+                "type": "object",
+                "properties": {"fallback": {"type": "string", "default": "metadata-default"}},
+            }
+        },
+        "versions": [
+            {
+                "id": 4,
+                "code": "selected version source",
+                "compiled": "compiled-selected",
+                "createdAt": "2026-01-02T00:00:00Z",
+                "paramsSchema": {
+                    "type": "object",
+                    "properties": {"mode": {"type": "string", "default": "review"}},
+                },
+            }
+        ],
+    }
+    monkeypatch.setattr(interface_cli.httpx, "Client", FakeHttpClient)
+
+    result = runner.invoke(
+        interface_cli.app,
+        [
+            "pull",
+            "--id",
+            "12",
+            "--version",
+            "4",
+            str(tmp_path),
+            "--token",
+            "token",
+            "--lse-url",
+            "http://ls",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / "Screen.jsx").read_text(encoding="utf-8") == "selected version source\n"
+    assert json.loads((tmp_path / "task.json").read_text(encoding="utf-8")) == {"text": "Pulled task"}
+    assert json.loads((tmp_path / "params.json").read_text(encoding="utf-8")) == {"mode": "review"}
+
+    sidecar = json.loads((tmp_path / "Screen.jsx.ls-interface.json").read_text(encoding="utf-8"))
+    assert sidecar["http://ls"]["interface_id"] == 12
+    assert sidecar["http://ls"]["title"] == "Pulled Interface"
+    assert sidecar["http://ls"]["workspace"] == 3
+    assert sidecar["http://ls"]["source_version"] == 4
+
+
+def test_preview_accepts_interface_directory(monkeypatch: Any, tmp_path: Path) -> None:
+    file = tmp_path / "Screen.jsx"
+    file.write_text("({ default: function Screen() { return null; } })", encoding="utf-8")
+    task = tmp_path / "sample.json"
+    task.write_text('{"text": "Example"}', encoding="utf-8")
+    calls: dict[str, Any] = {}
+
+    def fake_watch(*paths: Path, **kwargs: Any) -> Any:
+        calls["watch_paths"] = paths
+        calls["watch_kwargs"] = kwargs
+        raise KeyboardInterrupt
+        yield set()
+
+    _reset_fake_http()
+    monkeypatch.setitem(sys.modules, "watchfiles", SimpleNamespace(watch=fake_watch))
+    monkeypatch.setattr(interface_cli.httpx, "Client", FakeHttpClient)
+
+    result = runner.invoke(interface_cli.app, ["preview", str(tmp_path), "--lse-url", "http://ls", "--no-open"])
+
+    assert result.exit_code == 0, result.output
+    client = FakeHttpClient.instances[-1]
+    assert client.calls[0][0] == "POST"
+    payload = client.calls[0][2]
+    assert payload == {
+        "code": "({ default: function Screen() { return null; } })",
+        "task": {"text": "Example"},
+    }
+    assert calls["watch_paths"] == (file.resolve(), task.resolve())
 
 
 def test_start_syncs_then_creates_project(monkeypatch: Any, tmp_path: Path) -> None:
@@ -174,6 +508,7 @@ def test_start_syncs_then_creates_project(monkeypatch: Any, tmp_path: Path) -> N
 
     assert result.exit_code == 0, result.output
     assert calls["sync"]["file"] == file
+    assert calls["sync"]["publish"] is True
     assert calls["project"] == {
         "api_key": "token",
         "base_url": "http://ls",
@@ -185,3 +520,49 @@ def test_start_syncs_then_creates_project(monkeypatch: Any, tmp_path: Path) -> N
         "params": {"mode": "review"},
     }
     assert opened == ["http://ls/projects/45/data"]
+
+
+def test_start_accepts_interface_directory_and_params_default(monkeypatch: Any, tmp_path: Path) -> None:
+    file = tmp_path / "Screen.jsx"
+    file.write_text("({ default: function Screen() { return null; } })", encoding="utf-8")
+    params = tmp_path / "params.json"
+    params.write_text('{"mode": "review"}', encoding="utf-8")
+    calls: dict[str, Any] = {}
+
+    def fake_sync(**kwargs: Any) -> interface_cli.SyncResult:
+        calls["sync"] = kwargs
+        return interface_cli.SyncResult(
+            interface_id=12,
+            title="Demo",
+            status="created",
+            base_url="http://ls",
+            source_hash="abc",
+            source_version=2,
+            workspace_id=7,
+        )
+
+    def fake_create_project(**kwargs: Any) -> dict[str, Any]:
+        calls["project"] = kwargs
+        return {"id": 45}
+
+    monkeypatch.setattr(interface_cli, "_sync_interface", fake_sync)
+    monkeypatch.setattr(interface_cli, "_create_project", fake_create_project)
+    monkeypatch.setattr(interface_cli.webbrowser, "open", lambda _url: None)
+
+    result = runner.invoke(
+        interface_cli.app,
+        [
+            "start",
+            str(tmp_path),
+            "--token",
+            "token",
+            "--lse-url",
+            "http://ls",
+            "--no-open",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls["sync"]["file"] == file
+    assert calls["sync"]["publish"] is True
+    assert calls["project"]["params"] == {"mode": "review"}


### PR DESCRIPTION
Summary:
- add interface pull support for local bundles
- expand sync/start behavior around draft and published interface versions
- document the updated interface CLI flow

Tests:
- poetry run pytest tests/custom/cli/test_interface_cli.py -q